### PR TITLE
fix CGRect.insetBy

### DIFF
--- a/Sources/CGRect.swift
+++ b/Sources/CGRect.swift
@@ -76,7 +76,7 @@ extension CGRect {
     }
 
     public func insetBy(dx: CGFloat, dy: CGFloat) -> CGRect {
-        return CGRect(x: origin.x + dx, y: origin.y + dy, width: size.width + dx, height: size.height + dy)
+        return CGRect(x: origin.x + dx, y: origin.y + dy, width: size.width - dx * 2, height: size.height - dy * 2)
     }
 }
 


### PR DESCRIPTION
ich bin mir noch nicht 100% sicher, aber ich glaube so ist es richtig

**Return Value**
A rectangle. The origin value is offset in the x-axis by the distance specified by the dx parameter and in the y-axis by the distance specified by the dy parameter, and its size adjusted by (2*dx,2*dy), relative to the source rectangle. If dx and dy are positive values, then the rectangle’s size is decreased. If dx and dy are negative values, the rectangle’s size is increased.

https://developer.apple.com/documentation/coregraphics/cgrect/1454218-insetby