### PR TITLE
export AVPlayerItem import

### DIFF
--- a/Sources/AVPlayerItem+Mac.swift
+++ b/Sources/AVPlayerItem+Mac.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import AVFoundation
+@_exported import class AVFoundation.AVPlayerItem
+import struct AVFoundation.CMTime
 
-public typealias AVPlayerItem = AVFoundation.AVPlayerItem
 public typealias CMTime = AVFoundation.CMTime


### PR DESCRIPTION
<!-- Either add the type here or use a label and remove this part -->
**Type of change:** fix 

## Motivation
build of mac testapp is currently broken

## Current behavior
broken since xcode 9.3
```
undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_AVPlayerItem", referenced from:
      objc-class-ref in PlayerLoadingController.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Im not sure if this is a bug related to xcode 9.3 or expected behaviour

## Expected behavior
should build

### Please check if the PR fulfills these requirements
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Code runs on all relevant platforms (if major change: screenshots attached)
