### PR TITLE
Always run RunLoop (at least for a millisecond) per frame

### DIFF
--- a/Sources/UIKit+SDL.swift
+++ b/Sources/UIKit+SDL.swift
@@ -104,9 +104,7 @@ private let maxFrameRenderTimeInMilliseconds = 1000.0 / 60.0
 public func renderCalledFromJava(env: UnsafeMutablePointer<JNIEnv>, view: JavaObject) {
     let timeTaken = SDL.render()
     let remainingFrameTime = maxFrameRenderTimeInMilliseconds - timeTaken
-   
-    if remainingFrameTime > 0 {
-        CFRunLoopRunInMode(kCFRunLoopDefaultMode, remainingFrameTime / 1000, true)
-    }
+
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 1000), true)
 }
 #endif


### PR DESCRIPTION
**Type of change:** bugfix <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation

We had some issues where the `DispatchQueue.main` blocks only got drained sporadically and sometimes in a weird order etc. This ensures we're draining the main queue regularly. Early testing shows much more reliable network connections etc too with this change.

