### PR TITLE
implement UIImage(named: String)

### DIFF
--- a/Sources/UIImage.swift
+++ b/Sources/UIImage.swift
@@ -69,12 +69,12 @@ public class UIImage {
 
 private extension String {
     func pathAndExtension() -> (pathWithoutExtension: String, fileExtension: String) {
-        let path = self.asAbsolutePath() as NSString
+        let path = NSString(string: self.asAbsolutePath())
         return (path.deletingPathExtension, "." + path.pathExtension)
     }
 
     func extractImageScale() -> CGFloat {
-        let pathWithoutExtension = (self as NSString).deletingPathExtension
+        let pathWithoutExtension = NSString(string: self).deletingPathExtension
 
         if pathWithoutExtension.hasSuffix("@3x") {
             return 3.0


### PR DESCRIPTION
**Type of change:** feature

## Motivation

The most common way of loading images programatically on iOS is with the API `UIImage(named: String)`. That API doesn't require including a **file extension** or the **`@2x`** (etc) modifier to get the correct image type for your current screen settings.

We want to be able to use this API in our apps too.