### PR TITLE
Added horizontal scroll indicator and improved indicators' behaviour when deceleration animation is on

### DIFF
--- a/Sources/CGSize.swift
+++ b/Sources/CGSize.swift
@@ -33,7 +33,6 @@ extension CGSize {
     }
 }
 
-
 extension CGSize: CustomStringConvertible {
     public var description: String {
         return "(\(width), \(height))"

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -69,7 +69,7 @@ open class UIScrollView: UIView {
         setContentOffset(newOffset, animated: false)
     }
 
-    // does some min/max checks to prevent newOffset being out of bounds
+    /// does some min/max checks to prevent newOffset being out of bounds
     func getBoundsCheckedContentOffset(_ newContentOffset: CGPoint) -> CGPoint {
         return CGPoint(
             x: min(max(newContentOffset.x, -contentInset.left), (contentSize.width + contentInset.right) - bounds.width),
@@ -90,7 +90,7 @@ open class UIScrollView: UIView {
             //case .ended, .cancelled:
             //if contentOffset.x < contentInset.left {
             //    setContentOffset(CGPoint(x: contentInset.left, y: contentOffset.y), animated: true)
-        //}
+            //}
         default: break
         }
     }
@@ -115,7 +115,6 @@ open class UIScrollView: UIView {
     open func setContentOffset(_ point: CGPoint, animated: Bool) {
         precondition(point.x.isFinite)
         precondition(point.y.isFinite)
-
 
         contentOffset = point
 
@@ -142,17 +141,12 @@ open class UIScrollView: UIView {
     public func layoutScrollIndicatorsIfNeeded() {
         let shouldLayoutHorizontalScrollIndicator = showsHorizontalScrollIndicator && contentSize.width > bounds.width
         let shouldLayoutVerticalScrollIndicator = showsVerticalScrollIndicator && contentSize.height > bounds.height
-        if !shouldLayoutHorizontalScrollIndicator && !shouldLayoutVerticalScrollIndicator { return }
+        guard shouldLayoutHorizontalScrollIndicator || shouldLayoutVerticalScrollIndicator else { return }
 
-
-        // Q: since this only depends on bounds & size,can we avoid recalculating it here?
         let indicatorLengths = (horizontal: (bounds.width / contentSize.width) * bounds.width,
                                 vertical: (bounds.height / contentSize.height) * bounds.height)
 
-        // TODO: indicator lenghts and offsets are always rounded up to nearest 0.5 in iOS
-
         if shouldLayoutHorizontalScrollIndicator {
-
             horizontalScrollIndicator.frame = CGRect(
                 x: indicatorOffsetsInContentSpace().horizontal,
                 y: bounds.height - (indicatorThickness + indicatorDistanceFromScrollViewFrame),
@@ -199,9 +193,4 @@ public enum UIScrollViewIndicatorStyle {
         case .white: return UIColor.white
         }
     }
-
 }
-
-
-
-

--- a/UIKitTests/UIScrollViewTests.swift
+++ b/UIKitTests/UIScrollViewTests.swift
@@ -9,8 +9,8 @@
 import XCTest
 @testable import UIKit
 
-let initialSize = CGSize(width: 1000, height: 1000)
-let initialOrigin = CGPoint(x: 0, y: 0)
+private let initialSize = CGSize(width: 1000, height: 1000)
+private let initialOrigin = CGPoint(x: 0, y: 0)
 
 
 class UIScrollViewTests: XCTestCase {
@@ -41,16 +41,14 @@ class UIScrollViewTests: XCTestCase {
         let arbitraryContentOffset = CGPoint(x: 10, y: 20)
         scrollView.contentOffset = arbitraryContentOffset
         XCTAssertEqual(scrollView.bounds.origin, arbitraryContentOffset)
-        
-        
+
         let arbitraryContentSize = CGSize(width: 5, height: 10)
         scrollView.contentSize = arbitraryContentSize
         XCTAssertEqual(scrollView.contentSize, arbitraryContentSize)
-        
+
         let arbitraryContentInset = UIEdgeInsets(top: 12, left: 0, bottom: 2, right: 4)
         scrollView.contentInset = arbitraryContentInset
         XCTAssertEqual(scrollView.contentInset, arbitraryContentInset)
-        
     }
     
     
@@ -62,24 +60,18 @@ class UIScrollViewTests: XCTestCase {
         XCTAssertEqual(scrollView.verticalScrollIndicator.frame, CGRect.zero)
         XCTAssertEqual(scrollView.horizontalScrollIndicator.frame, CGRect.zero)
 
-
         mockTouch(toPoint: CGPoint(x: 100, y: 100), inScrollView: scrollView)
         XCTAssertEqual(scrollView.contentSize, CGSize.zero)
         XCTAssertEqual(scrollView.verticalScrollIndicator.frame, CGRect.zero)
         XCTAssertEqual(scrollView.horizontalScrollIndicator.frame, CGRect.zero)
-        
-        scrollView.contentSize = CGSize(width: 3000, height: 3000)
-        
-        
+
         // setting contenOffset artificially
         //TODO: chceck x and y separately
-        
+        scrollView.contentSize = CGSize(width: 3000, height: 3000)
         scrollView.contentOffset = CGPoint(x: 100, y: 100)
         XCTAssertNotEqual(scrollView.verticalScrollIndicator.frame, CGRect.zero)
         XCTAssertNotEqual(scrollView.horizontalScrollIndicator.frame, CGRect.zero)
-        
-        
-        
+
         // settingContentOffset with a drag
         // NOTE: scrollIndicators currently never fade out,
         // so this will always pass because they were already showing before
@@ -93,18 +85,15 @@ class UIScrollViewTests: XCTestCase {
     }
     
     func testScrollIndicatorsInitialAndFinalPositions() {
-        let scrollView = UIScrollView(frame: CGRect(origin: initialOrigin, size: initialSize))
-        
         scrollView.contentSize = CGSize(width: 3000, height: 3000)
         scrollView.contentOffset = CGPoint(x: 0, y: 0)
-        let desiredVerticalIndicatorStartPosition = CGPoint(x: scrollView.bounds.size.width - scrollView.indicatorThickness - scrollView.indicatorDistanceFromScrollViewFrame, y: 0 )
-        let desiredHorizontalIndicatorStartPosition = CGPoint(x: 0, y: scrollView.bounds.size.height - scrollView.indicatorThickness - scrollView.indicatorDistanceFromScrollViewFrame)
-        
-        XCTAssertEqual(scrollView.verticalScrollIndicator.frame.origin, desiredVerticalIndicatorStartPosition)
-        XCTAssertEqual(scrollView.horizontalScrollIndicator.frame.origin, desiredHorizontalIndicatorStartPosition)
-        
-        //TODO: final position. [blocked by setting contentOffset programatically - test behaviour in iOS]
+        let expectedHorizontalIndicatorStartPosition = CGPoint(x: 0, y: scrollView.bounds.size.height - scrollView.indicatorThickness - scrollView.indicatorDistanceFromScrollViewFrame)
+        let expectedVerticalIndicatorStartPosition = CGPoint(x: scrollView.bounds.size.width - scrollView.indicatorThickness - scrollView.indicatorDistanceFromScrollViewFrame, y: 0 )
 
+        XCTAssertEqual(scrollView.horizontalScrollIndicator.frame.origin, expectedHorizontalIndicatorStartPosition)
+        XCTAssertEqual(scrollView.verticalScrollIndicator.frame.origin, expectedVerticalIndicatorStartPosition)
+
+        //TODO: final position. [blocked by setting contentOffset programatically - test behaviour in iOS]
     }
     
 


### PR DESCRIPTION
Fixes # https://github.com/flowkey/UIKit-SDL/issues/195 + improves deceleration behaviour

<!-- Either add the type here or use a label and remove this part -->
**Type of change:**  feature + bug fix 

## Motivation
The horizontal indicator had not been implemented and was therefore not visible in ScrollableSheet view. When it was added, it was also not animating properly when the sheet deceleration animation was on.

## Todos
* [x] Implemented horizontal indicator (based on the code for vertical)
* [x] Improved behaviour of indicators under animation
* [x] Corrected the positioning of the indicators to take anchor point into account
* [x] Add tests 
* [ ] Implement bouncing (low priority at the moment) 

## Current behavior
Indicator in ScrollableSheet not visible.

## Expected behavior
Indicator in ScrollableSheet visible and behaving comparably to iOS.

### Please check if the PR fulfills these requirements
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Code runs on all relevant platforms (if major change: screenshots attached)