### PR TITLE
Correct S7, S8 test device display densities

### DIFF
--- a/Sources/GLRenderer.swift
+++ b/Sources/GLRenderer.swift
@@ -222,8 +222,8 @@ private extension CGSize {
     // smartphones:
     static let samsungGalaxyJ5 = CGSize(width: 1280 / 2.0, height: 720 / 2.0)
     static let samsungGalaxyS5 = CGSize(width: 1920 / 3.0, height: 1080 / 3.0)
-    static let samsungGalaxyS7 = CGSize(width: 2560 / 3.0, height: 1440 / 3.0) // 1080p 1.5x Retina
-    static let samsungGalaxyS8 = CGSize(width: 2960 / 3.0, height: 1440 / 3.0)
+    static let samsungGalaxyS7 = CGSize(width: 2560 / 4.0, height: 1440 / 4.0) // 1080p 1.5x Retina
+    static let samsungGalaxyS8 = CGSize(width: 2960 / 4.0, height: 1440 / 4.0)
 
     // tablets:
     static let nexus9 = CGSize(width: 2048 / 2.0, height: 1536 / 2.0)


### PR DESCRIPTION
<!-- Either add the type here or use a label and remove this part -->
**Type of change:** Quickfix<!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation
<!--- Explain briefly why this PR is needed / what problem it fixes -->
Have the correct display sizes for S7/S8 emulation on Mac for testing purposes

Source: https://material.io/tools/devices/ + manually tested

### Please check if the PR fulfills these requirements
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
