### PR TITLE
Added masks to bounds parameter translation in CALayer.swift

### DIFF
--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -200,6 +200,7 @@ open class CALayer {
         shadowRadius = layer.shadowRadius
         shadowOpacity = layer.shadowOpacity
         mask = layer.mask
+        masksToBounds = layer.masksToBounds
         contents = layer.contents // XXX: we should make a copy here
         contentsScale = layer.contentsScale
         superlayer = layer.superlayer


### PR DESCRIPTION
**Type of change:** bug fix

## Motivation
Noticed text overflow when artificially increased the number of lines in LearnStepNotifications. The reason was that maskToBounds was omitted in init(layer) of our CALayer implementation.



* [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
* [x] Tests for the changes have been added (for bug fixes / features)
* [x] Code runs on all relevant platforms (if major change: screenshots attached)
