### PR TITLE
Improved stability of AVPlayer's video display

### DIFF
--- a/Sources/AVPlayerLayer+Mac.swift
+++ b/Sources/AVPlayerLayer+Mac.swift
@@ -68,10 +68,13 @@ public final class AVPlayerLayer: CALayer {
         player?.currentItem?.remove(playerOutput)
 
         let aspectRatio = presentationSize.width / presentationSize.height
-        let widthAlignedTo4PixelPadding = (size.width.remainder(dividingBy: 4) == 0) ?
+        
+        
+        let widthAlignedTo4PixelPadding = (size.width.remainder(dividingBy: 8) == 0) ?
             size.width : // <-- no padding required
-            size.width + (4 - round(size.width).remainder(dividingBy: 4))
+            size.width + (8 - round(size.width).remainder(dividingBy: 8))
 
+        
         playerOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
             kCVPixelBufferOpenGLCompatibilityKey as String: true,


### PR DESCRIPTION
**Type of change:** Quickfix

## Motivation
When the app was run on Mac with Galaxy 8's screen size, the video was skewed.

Changing the divisor (as suggested by @ephemer) made the problem go away and to the best of my knowledge  did not break any of the other screen sizes (as it logically shouldn't).

#### Testing Details
I've ran the Mac app on all currently available screen sizes (4 phone, 6 tablet) and on a physical SGS5 and SM-T800. The video displays correctly on all of them

### Please check if the PR fulfills these requirements
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Code runs on all relevant platforms (if major change: screenshots attached)