### PR TITLE
Clean up SDL.render and make the runloop run for less time

### DIFF
--- a/Sources/UIKit+SDL.swift
+++ b/Sources/UIKit+SDL.swift
@@ -74,15 +74,7 @@ final public class SDL { // Only public for rootView!
         #endif
     }
 
-    /// Returns: time taken (in milliseconds) to render current frame
-    public static func render() -> Double {
-        let frameTimer = Timer()
-        doRender(at: frameTimer)
-        if shouldQuit { return -1.0 }
-        return frameTimer.elapsedTimeInMilliseconds
-    }
-
-    private static func doRender(at frameTimer: Timer) {
+    static func render(atTime frameTimer: Timer) {
         handleEventsIfNeeded()
         if shouldQuit || SDL.window == nil {
             print("Not rendering because `SDL.window` was `nil` or `shouldQuit == true`")
@@ -118,12 +110,13 @@ final public class SDL { // Only public for rootView!
 }
 
 #if os(Android)
-private let maxFrameRenderTimeInMilliseconds = 1000.0 / 60.0
+private let maxFrameRenderTimeInSeconds = 1.0 / 60.0
 
 @_silgen_name("Java_org_libsdl_app_SDLActivity_nativeRender")
 public func renderCalledFromJava(env: UnsafeMutablePointer<JNIEnv>, view: JavaObject) {
-    let timeTaken = SDL.render()
-    let remainingFrameTime = maxFrameRenderTimeInMilliseconds - timeTaken
-    CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 1000), true)
+    let frameTime = Timer()
+    SDL.render(atTime: frameTime)
+    let remainingFrameTime = maxFrameRenderTimeInSeconds - frameTime.elapsedTimeInSeconds
+    CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 2), true)
 }
 #endif


### PR DESCRIPTION
<!-- Either add the type here or use a label and remove this part -->
**Type of change:** cleanup

## Motivation

`SDL.render` for historical reasons was split into two parts. This has not been necessary for a long time. The newer code is easier to read and reason about and doesn't require passing around numbers between the various calls.

The functional change here is that we only run the runloop for half the remaining frame time (or 1ms minimum) instead of the entire remaining frame time. This gives us better rendering performance with no practical downsides.
