### PR TITLE
Cache exoplayer videos for better loading and seeking performance

### DIFF
--- a/UIKit-Android/uikit/src/main/java/org/uikit/VideoJNI.kt
+++ b/UIKit-Android/uikit/src/main/java/org/uikit/VideoJNI.kt
@@ -178,7 +178,7 @@ class AVPlayerLayer(private val parent: SDLActivity, player: AVPlayer) {
 
 
 ///// Caching data source
-// Thank you
+// Thank you https://stackoverflow.com/a/45488510/3086440
 
 private class CacheDataSourceFactory(private val context: Context, private val maxCacheSize: Long, private val maxFileSize: Long) : DataSource.Factory {
 


### PR DESCRIPTION
Fixes #145 

<!-- Either add the type here or use a label and remove this part -->
**Type of change:** Feature

## Motivation

We do a lot of waiting for Videos that are already loaded. In fact, the current implementation only holds a short buffer of the current video in memory and throws the rest away. This change should therefore greatly reduce mobile data usage while increasing performance.
