### PR TITLE
dont skip in surfaceChanged

### DIFF
--- a/UIKit-Android/uikit/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/UIKit-Android/uikit/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -268,7 +268,7 @@ open class SDLActivity(context: Context?) : RelativeLayout(context),
         }
 
         if (width == 0 || height == 0) {
-            Log.v(TAG, "skipping due to invalid dimensions: ${width} x ${height}")
+            Log.v(TAG, "skipping due to invalid surface dimensions: ${width} x ${height}")
             return
         }
 


### PR DESCRIPTION
Fixes https://github.com/flowkey/NativePlayerIOS/issues/484

<!-- Either add the type here or use a label and remove this part -->
**Type of change:** bugfix

## Motivation
we expect surfaceChanged to be called two times, but this may not happen on all devices.
If `surfaceChanged` is called once when in portrait mode, the app wont render.
This seems to happen on fast android 8 devices :neutral_face:
- Galaxy Note 8 (SM-N950F) - Android 8.0.0
- Huawei Mate 10 Pro (BLA-L29) Android 8.0.0

## Expected behavior
The app should render even when running on fast android 8 devices

#### Testing Details
tested with standalone testapp and when running from react-native

### Please check if the PR fulfills these requirements

* [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [x] The commit messages are clean and understandable
* [ ] Tests for the changes have been added (for bug fixes / features)
* [x] Code runs on all relevant platforms (if major change: screenshots attached)
