### PR TITLE
adding the IDEWorkspaceChecks file

### DIFF
--- a/UIKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/UIKit.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- Either add the type here or use a label and remove this part -->
**Type of change:** adding default Xcode 9.3 file


**Motivation**: adding a file that should be under version control, otherwise it keeps getting regenerated on our local machines. Having that file present is supposed to shorten build times by skipping some checks that are already marked as performed:

`Xcode 9.3 adds a new IDEWorkspaceChecks.plist file to a workspace’s shared data, to store the state of necessary workspace checks. Committing this file to source control will prevent unnecessary rerunning of those checks for each user opening the workspace. (37293167)`

https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-DontLinkElementID_7

https://stackoverflow.com/questions/49564513/new-file-created-in-xcode-9-3-wsname-xcworkspace-xcshareddata-ideworkspaceche
