### PR TITLE
enable rendering in portrait

### DIFF
--- a/UIKit-Android/uikit/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/UIKit-Android/uikit/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -1,5 +1,6 @@
 package org.libsdl.app
 
+import android.app.Activity
 import java.lang.reflect.Method
 
 import android.view.*
@@ -278,8 +279,11 @@ open class SDLActivity(context: Context?) : RelativeLayout(context),
             return
         }
 
-        mWidth = Math.max(width, height).toFloat()
-        mHeight = Math.min(width, height).toFloat()
+        val max = Math.max(width, height).toFloat()
+        val min = Math.min(width, height).toFloat()
+
+        mWidth = if (isLandscape) max else min
+        mHeight = if (isLandscape) min else max
 
         this.onNativeResize(mWidth.toInt(), mHeight.toInt(), sdlFormat, display.refreshRate)
         Log.v(TAG, "Window size: " + mWidth + "x" + mHeight)
@@ -323,4 +327,16 @@ open class SDLActivity(context: Context?) : RelativeLayout(context),
             layout(left, top, right, bottom)
         }
     }
+
+    val isLandscape: Boolean
+        get() {
+            val landscapeOrientations = arrayOf(
+                    ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
+                    ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
+                    ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE,
+                    ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+            )
+            val activity = context as Activity
+            return landscapeOrientations.contains(activity.requestedOrientation)
+        }
 }


### PR DESCRIPTION
<!-- Either add the type here or use a label and remove this part -->
**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation
It should be possible to render in portrait.

This approach works for orientations set from manifest.xml `android:screenOrientation="portrait"` and from code ` currentActivity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE`

### Please check if the PR fulfills these requirements
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
* [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
* [ ] The commit messages are clean and understandable
* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Code runs on all relevant platforms (if major change: screenshots attached)
