### PR TITLE
Add iOS Polyfills + instructions for them to the repo

### DIFF
--- a/iOS Polyfills/About Polyfills.md
+++ b/iOS Polyfills/About Polyfills.md
@@ -1,0 +1,13 @@
+## What is this folder? 
+
+iOS Polyfills are patch files that are necessary for many UIKit-crossplatform projects to work correctly with iOS. You will need them if you use `UIButton` or `UIGestureRecognizer`. 
+
+## How to use these files?
+
+Drag-and-drop them into your project and _make sure `Copy items if needed` is *unchecked*_ on the Xcode dialog. Once they are added to your project, please use UIKit-crossplatform API for the classes in question (rather than the native iOS API).
+
+For example, after adding `Button+iOS.swift`, you will need to change all your `UIButtons` to `Buttons` and use the appropriate API. The API is very similar, the most significant difference being how methods are added to Buttons. UIKit-crossplatform will require you to use `myButton.onPress = { /*a closure with some code*/}`, rather than `addTarget:`. Very often this will be the only necessary change, apart from Find-and-replace to use the `Button` keyword everywhere that you previously had `UIButtons`.
+
+## Why is this necessary?
+
+UIKit-crossplatform is written in Swift, while some parts of the API that UIKit uses are Objective-C. Things like the aforementioned `addTarget:` are not easily reproducible in Swift. We use these polyfill patch files as a solution (that hopefully we can still improve upon).

--- a/iOS Polyfills/Button+iOS.swift
+++ b/iOS Polyfills/Button+iOS.swift
@@ -1,17 +1,9 @@
-//
-//  Button.swift
-//  FlowkeyPlayer
-//
-//  Created by Geordie Jay on 17.05.17.
-//  Copyright © 2017 flowkey. All rights reserved.
-//
-
 import UIKit
 
 /**
  This class abstracts away the objc syntax for touch handling.
 
- The SDL Version is a direct subclass of UIView, so don't assume
+ The cross-platform version is a direct subclass of UIView, so don't assume
  that `Button` will always be a subclass of `UIButton`.
  */
 #if os(iOS)

--- a/iOS Polyfills/Button+iOS.swift
+++ b/iOS Polyfills/Button+iOS.swift
@@ -1,0 +1,34 @@
+//
+//  Button.swift
+//  FlowkeyPlayer
+//
+//  Created by Geordie Jay on 17.05.17.
+//  Copyright © 2017 flowkey. All rights reserved.
+//
+
+import UIKit
+
+/**
+ This class abstracts away the objc syntax for touch handling.
+
+ The SDL Version is a direct subclass of UIView, so don't assume
+ that `Button` will always be a subclass of `UIButton`.
+ */
+#if os(iOS)
+public class Button: UIButton {
+    public var onPress: (() -> Void)? {
+        didSet {
+            if onPress != nil {
+                // The docs say it is safe to add the same target/action multiple times:
+                addTarget(self, action: #selector(handleOnPress(_:)), for: .touchUpInside)
+            } else {
+                removeTarget(self, action: #selector(handleOnPress(_:)), for: .touchUpInside)
+            }
+        }
+    }
+
+    @objc private func handleOnPress(_ sender: Button) {
+        sender.onPress?()
+    }
+}
+#endif

--- a/iOS Polyfills/UIGestureRecognizer+Closures.swift
+++ b/iOS Polyfills/UIGestureRecognizer+Closures.swift
@@ -1,11 +1,3 @@
-//
-//  UIGestureRecognizer+Closures.swift
-//  FlowkeyPlayer
-//
-//  Created by Geordie Jay on 03.07.17.
-//  Copyright © 2017 flowkey. All rights reserved.
-//
-
 import UIKit
 
 #if os(iOS)

--- a/iOS Polyfills/UIGestureRecognizer+Closures.swift
+++ b/iOS Polyfills/UIGestureRecognizer+Closures.swift
@@ -1,0 +1,25 @@
+//
+//  UIGestureRecognizer+Closures.swift
+//  FlowkeyPlayer
+//
+//  Created by Geordie Jay on 03.07.17.
+//  Copyright © 2017 flowkey. All rights reserved.
+//
+
+import UIKit
+
+#if os(iOS)
+extension UIGestureRecognizer {
+    private static var handlers: [UIGestureRecognizer : (() -> Void)] = [:]
+
+    @nonobjc convenience init(onAction: @escaping (() -> Void)) {
+        self.init()
+        self.addTarget(self, action: #selector(actionHandler))
+        UIGestureRecognizer.handlers[self] = onAction
+    }
+
+    @objc private func actionHandler() {
+        UIGestureRecognizer.handlers[self]?()
+    }
+}
+#endif


### PR DESCRIPTION
**Type of change:** feature

## Motivation (current vs expected behavior)

Currently, UIButtons and UITapGestureRecognizers will not work out-of-the-box. `Button+iOS.swift` and `UIGestureRecognizer+Closures.swift` are required for projects that use them. This PR adds those files along with a short explanation of what they are/how to use them.


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable