### PR TITLE
removed calls from sizeToFit and layoutSubviews

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -234,7 +234,6 @@ open class UIView: UIResponder, CALayerDelegate {
     open func layoutSubviews() {
         needsLayout = false
         parentViewController?.viewWillLayoutSubviews()
-        subviews.forEach { $0.setNeedsLayout() }
         parentViewController?.viewDidLayoutSubviews()
     }
 
@@ -344,7 +343,6 @@ open class UIView: UIResponder, CALayerDelegate {
         let originalOrigin = self.frame.origin
         self.bounds.size = sizeThatFits(bounds.size)
         self.frame.origin = originalOrigin
-        setNeedsLayout()
     }
 
     // We originally had this in an extension but Swift functions in extensions cannot be overridden (as of Swift 4)


### PR DESCRIPTION
Related to #137 

**Type of change:** code fix 

## Motivation

When trying to track every call on the UIView lifecycle (setNeedsLayout, layoutSubviews, sizeToFit etc.), I noticed many more of those calls appearing in UIKit-x version than iOS version. Removing those two `setNeedsLayout` calls from `UIView` made it much more (albeit not perfectly) consistent with the way these calls happen in iOS.

The benefit of these changes is removing unnecessary calls (and lines of code that might be extra confusing, since they don't provide value, but are in the code). 

The risk is that some those calls needed to be there after all and removing them will cause some elements to stop displaying correctly. This forces us to take a look at each screen and compare to a non-changed version. Since the change is removing setNeedsDisplay commands, the problems that can be expected would be views misplaced for a brief moment of time or before some action is taken by the user. I went through all screens of Player I could think of and did not notice any differences in layout. I covered part of that (the 'SongOrSlide' flow) with screenshots, included below. There don't seem to be any differences in layout, suggesting the changes are safe to include.


When comparing screenshots:
*  please note that they were shot 'manually' so the screenshot itself may be a little off
* use zoom in the browser to get a better view

current master (no change) | this PR (with change
------------ | -------------
<img width="639" alt="screen shot 2018-08-15 at 19 25 20" src="https://user-images.githubusercontent.com/2146927/44162916-099a3200-a0c2-11e8-8351-567e63034ede.png"> |  <img width="642" alt="screen shot 2018-08-15 at 17 51 02" src="https://user-images.githubusercontent.com/2146927/44162930-13239a00-a0c2-11e8-8775-2ede7eb7e866.png">
<img width="640" alt="screen shot 2018-08-15 at 19 25 30" src="https://user-images.githubusercontent.com/2146927/44162970-33535900-a0c2-11e8-8b33-b7c8099480cf.png"> |  <img width="640" alt="screen shot 2018-08-15 at 17 50 33" src="https://user-images.githubusercontent.com/2146927/44162976-39493a00-a0c2-11e8-9687-29fad7e2231e.png">
<img width="641" alt="screen shot 2018-08-15 at 19 25 37" src="https://user-images.githubusercontent.com/2146927/44163061-8c22f180-a0c2-11e8-9e56-f46dc07d3381.png"> |  <img width="641" alt="screen shot 2018-08-15 at 17 50 50" src="https://user-images.githubusercontent.com/2146927/44163066-904f0f00-a0c2-11e8-92ef-3a46fbf13c0b.png">
<img width="640" alt="screen shot 2018-08-15 at 19 25 48" src="https://user-images.githubusercontent.com/2146927/44163084-9c3ad100-a0c2-11e8-85cd-62a01780c73a.png"> |  <img width="640" alt="screen shot 2018-08-15 at 17 51 31" src="https://user-images.githubusercontent.com/2146927/44163094-a230b200-a0c2-11e8-8d84-769e33363461.png">
<img width="644" alt="screen shot 2018-08-15 at 17 52 10" src="https://user-images.githubusercontent.com/2146927/44163100-a9f05680-a0c2-11e8-8c0b-14e29242b7e5.png"> |  <img width="638" alt="screen shot 2018-08-15 at 19 26 25" src="https://user-images.githubusercontent.com/2146927/44163104-b07ece00-a0c2-11e8-9f28-d2f1ca26dea1.png">
<img width="639" alt="screen shot 2018-08-15 at 19 27 58" src="https://user-images.githubusercontent.com/2146927/44163111-b7a5dc00-a0c2-11e8-88be-c5fb275b48e3.png"> |  <img width="638" alt="screen shot 2018-08-15 at 17 52 18" src="https://user-images.githubusercontent.com/2146927/44163113-bbd1f980-a0c2-11e8-8d8e-0b434bbe94b9.png">







## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable