### PR TITLE
Use @_cdecl instead of @_silgen_name where possible

### DIFF
--- a/Sources/AVPlayer+Android.swift
+++ b/Sources/AVPlayer+Android.swift
@@ -55,18 +55,18 @@ public class AVPlayer: JNIObject {
 
 private weak var globalAVPlayer: AVPlayer?
 
-@_silgen_name("Java_org_uikit_AVPlayer_nativeOnVideoReady")
+@_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoReady")
 public func nativeOnVideoReady(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
     globalAVPlayer?.onLoaded?(nil)
     globalAVPlayer?.onLoaded = nil
 }
 
-@_silgen_name("Java_org_uikit_AVPlayer_nativeOnVideoEnded")
+@_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoEnded")
 public func nativeOnVideoEnded(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
     globalAVPlayer?.onVideoEnded?()
 }
 
-@_silgen_name("Java_org_uikit_AVPlayer_nativeOnVideoSourceError")
+@_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoSourceError")
 public func nativeOnVideoSourceError(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
     globalAVPlayer?.onLoaded?(AVPlayer.DataSourceError())
     globalAVPlayer?.onLoaded = nil

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -128,7 +128,7 @@ import JNI
 
 private let maxFrameRenderTimeInSeconds = 1.0 / 60.0
 
-@_silgen_name("Java_org_libsdl_app_SDLActivity_nativeRender")
+@_cdecl("Java_org_libsdl_app_SDLActivity_nativeRender")
 public func renderCalledFromJava(env: UnsafeMutablePointer<JNIEnv>, view: JavaObject) {
     let frameTime = Timer()
     UIApplication.shared.render(atTime: frameTime)

--- a/samples/getting-started/DemoApp/androidMain.swift
+++ b/samples/getting-started/DemoApp/androidMain.swift
@@ -1,7 +1,7 @@
 import JNI
 import UIKit
 
-@_silgen_name("JNI_OnLoad")
+@_cdecl("JNI_OnLoad")
 public func JNI_OnLoad(jvm: UnsafeMutablePointer<JavaVM>, reserved: UnsafeMutableRawPointer) -> JavaInt {
     UIKitAndroid.UIApplicationDelegateClass = AppDelegate.self
 


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)

When passing more than two parameters to a function via JNI, we discovered that the values of the third and following parameters don't make any sense.
Using `@_cdecl` instead of `@_silgen_name` fixes this. This PR does some preventive maintenance in order to avoid future errors.


## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)