### PR TITLE
(Mostly) Android: Fix crashes and render bugs after recreating GLContext

### DIFF
--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -103,13 +103,22 @@ extension CALayer {
         }
 
         if let contents = contents {
-            renderer.blit(
-                contents,
-                anchorPoint: anchorPoint,
-                contentsScale: contentsScale,
-                contentsGravity: ContentsGravityTransformation(for: self),
-                opacity: opacity
-            )
+            do {
+                try renderer.blit(
+                    contents,
+                    anchorPoint: anchorPoint,
+                    contentsScale: contentsScale,
+                    contentsGravity: ContentsGravityTransformation(for: self),
+                    opacity: opacity
+                )
+            } catch {
+                // Try to recreate contents from source data if it exists
+                if contents.reloadFromSourceData() == false {
+                    // That failed, rely on the layer to re-render itself:
+                    self.contents = nil
+                    self.setNeedsDisplay()
+                }
+            }
         }
 
         if mask != nil {
@@ -125,7 +134,7 @@ extension CALayer {
             let translationFromAnchorPointToOrigin = CATransform3DMakeTranslation(
                 deltaFromAnchorPointToOrigin.x - bounds.origin.x,
                 deltaFromAnchorPointToOrigin.y - bounds.origin.y,
-                0 // If we moved (e.g.) forward to render `self`, all sublayers should start at the same zIndex
+                0 // If we moved (e.g.) forward to render `self`, all sublayers should start at that same zIndex
             )
 
             // This transform is referred to as the `parentOriginTransform` in our sublayers (see above):

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -241,9 +241,9 @@ open class CALayer {
     internal var _presentation: CALayer?
     open func presentation() -> CALayer? { return _presentation }
 
-    var disableAnimations = false
+    internal var disableAnimations = false
 
-    var animations = [String: CABasicAnimation]() {
+    internal var animations = [String: CABasicAnimation]() {
         didSet { onDidSetAnimations(wasEmpty: oldValue.isEmpty) }
     }
 
@@ -251,6 +251,13 @@ open class CALayer {
     /// This is both a performance optimization (avoids lots of animations at the start)
     /// as well as a correctness fix (matches iOS behaviour). Maybe there's a better way though?
     internal var hasBeenRenderedInThisPartOfOverallLayerHierarchy = false
+
+    internal var _needsDisplay = true
+    open func needsDisplay() -> Bool { return _needsDisplay }
+    open func setNeedsDisplay() { _needsDisplay = true }
+    open func display() {
+        delegate?.display(self)
+    }
 }
 
 private extension CGPoint {
@@ -299,4 +306,5 @@ extension CALayer: Hashable {
 
 public protocol CALayerDelegate: class {
     func action(forKey event: String) -> CABasicAnimation?
+    func display(_ layer: CALayer)
 }

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -11,7 +11,13 @@ import SDL_gpu
 import Foundation
 
 public class CGImage {
-    let rawPointer: UnsafeMutablePointer<GPU_Image>
+    /// Be careful using this pointer e.g. for another CGImage instance.
+    /// You will have to manually adjust its pointee's reference count.
+    var rawPointer: UnsafeMutablePointer<GPU_Image>
+
+    /// Stores the compressed image `Data` this `CGImage` was inited with (if any).
+    /// This allows us to recreate the image if our OpenGL Context gets killed (esp. relevant for Android)
+    private let sourceData: Data?
 
     public let width: Int
     public let height: Int
@@ -19,7 +25,7 @@ public class CGImage {
     /**
      Initialize a `CGImage` by passing a reference to a `GPU_Image`, which is usually the result of SDL_gpu's `GPU_*Image*` creation functions. May be null.
      */
-    internal init?(_ pointer: UnsafeMutablePointer<GPU_Image>?) {
+    internal init?(_ pointer: UnsafeMutablePointer<GPU_Image>?, sourceData: Data? = nil) {
         guard let pointer = pointer else {
             // We check for GPU errors on render, so clear any error that may have caused GPU_Image to be nil.
             // It's possible there are unrelated errors on the stack at this point, but we immediately catch and
@@ -28,6 +34,7 @@ public class CGImage {
             return nil
         }
 
+        self.sourceData = sourceData
         rawPointer = pointer
 
         GPU_SetSnapMode(rawPointer, GPU_SNAP_POSITION_AND_DIMENSIONS)
@@ -38,16 +45,66 @@ public class CGImage {
         height = Int(rawPointer.pointee.h)
     }
 
-    convenience init?(surface: UnsafeMutablePointer<SDLSurface>) {
-        self.init(GPU_CopyImageFromSurface(surface))
+    internal convenience init?(_ sourceData: Data) {
+        var data = sourceData
+        let dataCount = Int32(data.count)
+
+        guard let gpuImagePtr = data.withUnsafeMutableBytes({ (ptr: UnsafeMutablePointer<Int8>) -> UnsafeMutablePointer<GPU_Image>? in
+            let rw = SDL_RWFromMem(ptr, dataCount)
+            return GPU_LoadImage_RW(rw, true)
+        }) else { return nil }
+
+        self.init(gpuImagePtr, sourceData: data)
     }
 
-    func replacePixels(with bytes: UnsafePointer<UInt8>, bytesPerPixel: Int) {
+    convenience init?(surface: UnsafeMutablePointer<SDLSurface>) {
+        guard let pointer = GPU_CopyImageFromSurface(surface) else { return nil }
+        self.init(pointer)
+    }
+
+    internal func replacePixels(with bytes: UnsafePointer<UInt8>, bytesPerPixel: Int) {
         var rect = GPU_Rect(x: 0, y: 0, w: Float(rawPointer.pointee.w), h: Float(rawPointer.pointee.h))
         GPU_UpdateImageBytes(rawPointer, &rect, bytes, Int32(rawPointer.pointee.w) * Int32(bytesPerPixel))
     }
 
+    /// Recreate the underlying `GPU_Image` (`self.rawPointer`) from this `CGImage`'s source data if possible.
+    /// - Returns: `true`, if it was possible to recreate the image. Or `false`, if there was no underlying source data, or when SDL_gpu could not decode that data.
+    internal func reloadFromSourceData() -> Bool {
+        guard let sourceData = sourceData, let newImage = CGImage(sourceData) else {
+            return false
+        }
+
+        // Free the old GPU_Image before replacing it (this may be our last chance)
+        GPU_FreeImage(rawPointer)
+
+        // If we don't increase the new image's refcount it will be deinited along
+        // with the CGImageRef that goes out of scope at the end of this function.
+        newImage.rawPointer.pointee.refcount += 1
+
+        self.rawPointer = newImage.rawPointer
+
+        return true
+    }
+
     deinit {
         GPU_FreeImage(rawPointer)
+    }
+
+    public func pngData() -> Data? {
+        guard let surface = GPU_CopySurfaceFromImage(rawPointer) else { return nil }
+        defer { SDL_FreeSurface(surface) }
+
+        let pngWritingFunc: @convention(c) (UnsafeMutableRawPointer?, UnsafeMutableRawPointer?, Int32) -> Void = { (outData, pngData, dataSize) in
+            guard let pngData = pngData, dataSize > 0 else { return }
+            outData?.assumingMemoryBound(to: Data.self)
+                .pointee
+                .append(pngData.assumingMemoryBound(to: UInt8.self), count: Int(dataSize))
+        }
+
+        return withoutActuallyEscaping(pngWritingFunc) { (closure) -> Data? in
+            var data = Data()
+            stbi_write_png_to_func(closure, &data, surface.pointee.w, surface.pointee.h, Int32(surface.pointee.format.pointee.BytesPerPixel), surface.pointee.pixels, surface.pointee.pitch)
+            return data.count > 0 ? data : nil
+        }
     }
 }

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -26,8 +26,9 @@ public class CGImage {
 
     /**
      Initialize a `CGImage` by passing a reference to a `GPU_Image`, which is usually the result of SDL_gpu's `GPU_*Image*` creation functions. May be null.
+     The second parameter provides the compressed image source data (in PNG, JPG etc. format). The source data will be used to recreate the `GPU_Image` if the GLContext has been invalidated (which happens quite commonly on Android). Not providing source data means you will have to recreate the `CGImage` yourself if it fails to render, usually by overriding your `CALayer`'s display() method.
      */
-    internal init?(_ pointer: UnsafeMutablePointer<GPU_Image>?, sourceData: Data? = nil) {
+    internal init?(_ pointer: UnsafeMutablePointer<GPU_Image>?, sourceData: Data?) {
         guard let pointer = pointer else {
             // We check for GPU errors on render, so clear any error that may have caused GPU_Image to be nil.
             // It's possible there are unrelated errors on the stack at this point, but we immediately catch and
@@ -61,7 +62,7 @@ public class CGImage {
 
     convenience init?(surface: UnsafeMutablePointer<SDLSurface>) {
         guard let pointer = GPU_CopyImageFromSurface(surface) else { return nil }
-        self.init(pointer)
+        self.init(pointer, sourceData: nil)
     }
 
     internal func replacePixels(with bytes: UnsafePointer<UInt8>, bytesPerPixel: Int) {

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -13,7 +13,9 @@ import Foundation
 public class CGImage {
     /// Be careful using this pointer e.g. for another CGImage instance.
     /// You will have to manually adjust its pointee's reference count.
-    var rawPointer: UnsafeMutablePointer<GPU_Image>
+    var rawPointer: UnsafeMutablePointer<GPU_Image> {
+        didSet { CALayer.layerTreeIsDirty = true }
+    }
 
     /// Stores the compressed image `Data` this `CGImage` was inited with (if any).
     /// This allows us to recreate the image if our OpenGL Context gets killed (esp. relevant for Android)

--- a/Sources/Data+fromRelativePathCrossPlatform.swift
+++ b/Sources/Data+fromRelativePathCrossPlatform.swift
@@ -1,0 +1,38 @@
+//
+//  Data+fromRelativePathCrossPlatform.swift
+//  UIKit
+//
+//  Created by Geordie Jay on 01.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    static func fromPathCrossPlatform(_ path: String) -> Data? {
+        #if !os(Android)
+        // At time of writing the SDL code below worked on all supported SDL platforms.
+        // But, because of some crashes in `Data` we're doing an unneccessary copy there
+        // which makes that version less efficient than Foundation's, so use it here instead:
+        return try? Data(contentsOf: URL(fileURLWithPath: path))
+        #else
+        guard let fileReader = SDL_RWFromFile(path, "r") else {
+            return nil
+        }
+
+        defer { _ = fileReader.pointee.close(fileReader) }
+
+        let fileSize = Int(fileReader.pointee.size(fileReader))
+
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: fileSize)
+        defer { buffer.deallocate() }
+
+        let bytesRead = fileReader.pointee.read(fileReader, buffer, 1, fileSize)
+        if bytesRead == fileSize {
+            return Data(bytes: buffer, count: fileSize)
+        } else {
+            return nil
+        }
+        #endif
+    }
+}

--- a/Sources/FontRenderer+renderAttributedString.swift
+++ b/Sources/FontRenderer+renderAttributedString.swift
@@ -20,7 +20,7 @@ extension FontRenderer {
 
         var xOffset: Int32 = 0
 
-        // Adding bound checking to avoid all kinds of memory corruption errors
+        // Bounds checking to avoid memory corruption errors
         let surfaceEndIndex = surface.pointee.pixels.assumingMemoryBound(to: UInt32.self)
             + Int(surface.pointee.pitch / 4 * surface.pointee.h)
 

--- a/Sources/FontRenderer+singleLineSize.swift
+++ b/Sources/FontRenderer+singleLineSize.swift
@@ -116,7 +116,7 @@ extension FontRenderer {
             }
 
             guard Find_Glyph(self.rawPointer, characterCode, CACHED_METRICS) == 0 else {
-                assertionFailure("Couldn't find glyph")
+                print("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') could not be found")
                 return nil
             }
 
@@ -124,7 +124,7 @@ extension FontRenderer {
 
             let spaceCharacterCode = 32
             if characterCode != spaceCharacterCode, glyph.maxx - glyph.minx <= 0 {
-                assertionFailure("Glyph has no width")
+                print("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') has no width")
                 return nil
             }
 

--- a/Sources/FontRenderer+singleLineSize.swift
+++ b/Sources/FontRenderer+singleLineSize.swift
@@ -116,7 +116,7 @@ extension FontRenderer {
             }
 
             guard Find_Glyph(self.rawPointer, characterCode, CACHED_METRICS) == 0 else {
-                print("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') could not be found")
+                assertionFailure("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') could not be found")
                 return nil
             }
 
@@ -124,7 +124,7 @@ extension FontRenderer {
 
             let spaceCharacterCode = 32
             if characterCode != spaceCharacterCode, glyph.maxx - glyph.minx <= 0 {
-                print("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') has no width")
+                assertionFailure("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') has no width")
                 return nil
             }
 

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -8,8 +8,20 @@
 
 import SDL_ttf
 
-private func initSDL_ttf() -> Bool {
-    return (TTF_WasInit() == 1) || (TTF_Init() != -1) // TTF_Init returns -1 on failure
+
+extension FontRenderer {
+    /// Stores the renderers for a specific Name/Size UIFont configuration to avoid reiniting them all the time.
+    static var cache = [String: FontRenderer]()
+
+    /// Called whenever the UIScreen is destroyed to avoid strange font rendering bugs on reinit.
+    static func cleanupSession() {
+        cache.removeAll()
+        TTF_Quit()
+    }
+
+    private static func initialize() -> Bool {
+        return (TTF_WasInit() == 1) || (TTF_Init() != -1)
+    }
 }
 
 public class FontRenderer {
@@ -17,7 +29,7 @@ public class FontRenderer {
     deinit { TTF_CloseFont(rawPointer) }
 
     init?(_ source: CGDataProvider, size: Int32) {
-        if !initSDL_ttf() { return nil }
+        if !FontRenderer.initialize() { return nil }
 
         let rwOp = SDL_RWFromConstMem(source.data, Int32(source.data.count))
         guard let font = TTF_OpenFontRW(rwOp, 1, size) else { return nil }

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -67,7 +67,8 @@ extension UIApplication {
 
                 if keyModifier.contains(KMOD_LGUI) || keyModifier.contains(KMOD_RGUI) {
                     if e.key.keysym.sym == 114 { // CMD-R
-                        UIApplication.restart()
+                        UIScreen.main = nil
+                        UIScreen.main = UIScreen()
                     }
                 }
                 #endif
@@ -93,29 +94,29 @@ extension UIApplication {
 
 extension UIApplication {
     static func onWillEnterForeground() {
-        UIApplication.restart {
-            if let runningApplication = UIApplication.shared {
-                runningApplication.delegate?.applicationWillEnterForeground(runningApplication)
-            }
+        #if os(Android)
+        if UIScreen.main == nil { // sometimes we "enter foreground" after just a loss of focus
+            UIScreen.main = UIScreen()
         }
+        #endif
+
+        UIApplication.shared?.delegate?.applicationWillEnterForeground(UIApplication.shared)
     }
 
     static func onDidEnterForeground() {
-        if let runningApplication = UIApplication.shared {
-            runningApplication.delegate?.applicationDidBecomeActive(runningApplication)
-        }
+        UIApplication.shared?.delegate?.applicationDidBecomeActive(UIApplication.shared)
     }
 
     static func onWillEnterBackground() {
-        if let runningApplication = UIApplication.shared {
-            runningApplication.delegate?.applicationWillResignActive(runningApplication)
-        }
+        UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
     }
 
     static func onDidEnterBackground() {
-        if let runningApplication = UIApplication.shared {
-            runningApplication.delegate?.applicationDidEnterBackground(runningApplication)
-        }
+        UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
+
+        #if os(Android)
+        UIScreen.main = nil
+        #endif
     }
 }
 

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -51,6 +51,7 @@ open class UIApplication {
 
     public required init() {
         UIScreen.main = UIScreen()
+        UIFont.loadSystemFonts()
     }
 
     deinit {

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -54,8 +54,9 @@ open class UIApplication {
     }
 
     deinit {
-        DisplayLink.activeDisplayLinks.removeAll()
         UIScreen.main = nil
+        UIFont.clearCachedFontFiles()
+        DisplayLink.activeDisplayLinks.removeAll()
     }
 }
 

--- a/Sources/UIApplicationMain+Mac.swift
+++ b/Sources/UIApplicationMain+Mac.swift
@@ -30,7 +30,7 @@ func setupRenderAndRunLoop() {
             let currentTime = Timer()
             DispatchQueue.main.async {
                 UIApplication.shared.handleEventsIfNeeded()
-                UIApplication.shared.render(atTime: currentTime)
+                UIScreen.main.render(window: UIApplication.shared.keyWindow, atTime: currentTime)
             }
          }
 

--- a/Sources/UIApplicationMain.swift
+++ b/Sources/UIApplicationMain.swift
@@ -49,9 +49,7 @@ internal func UIApplicationMain(
 
     application.delegate = appDelegate
 
-    if
-        !appDelegate.application(application, didFinishLaunchingWithOptions: nil)
-    {
+    if appDelegate.application(application, didFinishLaunchingWithOptions: nil) == false {
         return 1
     }
 

--- a/Sources/UIApplicationMain.swift
+++ b/Sources/UIApplicationMain.swift
@@ -35,7 +35,8 @@ internal func UIApplicationMain(
     _ applicationClass: UIApplication.Type?,
     _ applicationDelegateClass: UIApplicationDelegate.Type?) -> Int32
 {
-    UIApplication.shared = (applicationClass ?? UIApplication.self).init()
+    let application = (applicationClass ?? UIApplication.self).init()
+    UIApplication.shared = application
 
     guard let appDelegate = applicationDelegateClass?.init() else {
         // iOS doesn't create a window by default either
@@ -46,32 +47,13 @@ internal func UIApplicationMain(
         return 1
     }
 
-    UIApplication.shared.delegate = appDelegate
-    if !appDelegate.application(UIApplication.shared, didFinishLaunchingWithOptions: nil) {
-        // on iOS I think this prevents launching the app?
-        assertionFailure("Returned false from AppDelegate, stopping launch")
+    application.delegate = appDelegate
+
+    if
+        !appDelegate.application(application, didFinishLaunchingWithOptions: nil)
+    {
         return 1
     }
 
     return 0
-}
-
-extension UIApplication {
-    static func restart(_ onRestarted: (() -> Void)? = nil) {
-        guard UIApplication.shared != nil else {
-            print("Tried to restart but no application was running")
-            return
-        }
-
-        let applicationType = type(of: UIApplication.shared!)
-        let delegateType = UIApplication.shared!.delegate != nil ? type(of: UIApplication.shared!.delegate!).self : nil
-
-        UIApplication.shared = nil
-
-        DispatchQueue.main.async {
-            // Wrap this in another async block because UIApplicationMain is blocking on Mac:
-            DispatchQueue.main.async { onRestarted?() }
-            UIApplicationMain(applicationType, delegateType)
-        }
-    }
 }

--- a/Sources/UIColor.swift
+++ b/Sources/UIColor.swift
@@ -8,7 +8,7 @@
 
 import SDL
 
-public class UIColor: Equatable {
+public class UIColor: Hashable {
     let red: UInt8
     let green: UInt8
     let blue: UInt8
@@ -76,6 +76,15 @@ public class UIColor: Equatable {
     // Initialise from a color struct from e.g. renderer.getDrawColor()
     init(_ tuple: (r: UInt8, g: UInt8, b: UInt8, a: UInt8)) {
         red = tuple.r; green = tuple.g; blue = tuple.b; alpha = tuple.a
+    }
+
+    public var hashValue: Int {
+        return (
+            UInt32(red) << 24 +
+            UInt32(green) << 16 +
+            UInt32(blue) << 8 +
+            UInt32(alpha)
+        ).hashValue
     }
 }
 

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -8,9 +8,13 @@
 
 open class UIFont {
     public let fontName: String
-    public var familyName: String?
+    public var familyName: String? {
+        return renderer?.getFontFamilyName()
+    }
     public var pointSize: CGFloat
-    public let lineHeight: CGFloat
+    public var lineHeight: CGFloat {
+        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.main.scale
+    }
 
     /**
         Change this value after loading the desired system font via `UIFont.loadFont(fromPath: String)`.
@@ -32,51 +36,58 @@ open class UIFont {
         let name = name.lowercased()
         let size = Int32(size * UIScreen.main.scale)
 
-        guard let fontData = UIFont.availableFontData[name] else {
-            print("Tried to load \(name) but it wasn't in UIFont.availableFonts: \(UIFont.availableFontData)")
-            return nil
-        }
-
-        let cacheKey = name + String(describing: size)
-        guard let renderer = UIFont.fontRendererCache[cacheKey] ?? FontRenderer(fontData, size: size) else {
-            print("Couldn't load font", name)
-            return nil
-        }
-
-        UIFont.fontRendererCache[cacheKey] = renderer
-        self.renderer = renderer
         self.fontName = name
-        self.familyName = renderer.getFontFamilyName() ?? "<unknown>"
         self.pointSize = CGFloat(size)
-        self.lineHeight = CGFloat(renderer.getLineHeight()) / UIScreen.main.scale
     }
 
     // MARK: Implementation details:
 
     /// Renderer is the interface to our rendering backend (at time of writing, SDL_ttf)
     /// If we ever want to change the backend, we should only have to change the FontRenderer class:
-    fileprivate let renderer: FontRenderer
+    fileprivate var renderer: FontRenderer? {
+        // We access the renderer from the cache every time because it may have been replaced since this UIFont was inited
+        guard let fontData = UIFont.cachedFontFiles[fontName] else {
+            print("Tried to load \(fontName) but it wasn't in UIFont.__availableFonts: \(UIFont.cachedFontFiles)")
+            return nil
+        }
+
+        let cacheKey = fontName + String(describing: pointSize)
+
+        if let renderer = FontRenderer.cache[cacheKey] {
+            return renderer
+        }
+
+        guard let newlyLoadedRenderer = FontRenderer(fontData, size: Int32(pointSize)) else {
+            return nil
+        }
+
+        FontRenderer.cache[cacheKey] = newlyLoadedRenderer
+        return newlyLoadedRenderer
+    }
 
     internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0) -> CGImage? {
-        return renderer.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale))
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale))
     }
 
     internal func render(_ attributedString: NSAttributedString?, color: UIColor, wrapLength: CGFloat = 0) -> CGImage? {
-        return renderer.render(attributedString, color: color)
+        return renderer?.render(attributedString, color: color)
     }
 }
 
 // MARK: Caches
 extension UIFont {
-    static var fontRendererCache = [String: FontRenderer]()
-    fileprivate static var availableFontData: [String: CGDataProvider] = [:]
-    static public var availableFonts: [String] {
-        return Array(availableFontData.keys)
+    /// We store the TTF files we load into memory so we can quickly make more `FontRenderer` instances.
+    private static var cachedFontFiles: [String: CGDataProvider] = [:]
+
+    /// We call this when deinitialising the UIApplication to recover the memory they used
+    static func clearCachedFontFiles() {
+        cachedFontFiles.removeAll()
     }
 
-    public static func clearCaches() {
-        fontRendererCache.removeAll()
-        availableFontData.removeAll()
+    /// A list of Fonts loaded by and available to UIKit Cross Platform.
+    /// Note: this API is subject to change.
+    static public var __availableFonts: [String] {
+        return Array(cachedFontFiles.keys)
     }
 }
 
@@ -141,7 +152,7 @@ extension UIFont {
         let fontStyleName = fontRenderer.getFontStyleName() ?? "unknown"
         let fontName = "\(fontFamilyName)-\(fontStyleName)".lowercased()
 
-        UIFont.availableFontData[fontName] = dataProvider
+        UIFont.cachedFontFiles[fontName] = dataProvider
 
         return fontRenderer
     }
@@ -153,18 +164,21 @@ extension UIFont {
 
 extension NSAttributedString {
     public func size(with font: UIFont, wrapLength: CGFloat = 0) -> CGSize {
+        guard let renderer = font.renderer else { return .zero }
         return wrapLength == 0 ?
-            font.renderer.singleLineSize(of: self) / UIScreen.main.scale :
+            renderer.singleLineSize(of: self) / UIScreen.main.scale :
             string.size(with: font, wrapLength: wrapLength) // fallback to String.size for multiline text
     }
 }
 
 extension String {
     public func size(with font: UIFont, wrapLength: CGFloat = 0) -> CGSize {
+        guard let renderer = font.renderer else { return .zero }
+
         let retinaResolutionSize =
             (wrapLength <= 0) ? // a wrapLength of < 0 leads to a crash, so assume 0
-                font.renderer.singleLineSize(of: self) :
-                font.renderer.multilineSize(
+                renderer.singleLineSize(of: self) :
+                renderer.multilineSize(
                     of: self,
                     wrapLength: UInt(wrapLength * UIScreen.main.scale)
                 )

--- a/Sources/UIImage.swift
+++ b/Sources/UIImage.swift
@@ -28,42 +28,40 @@ public class UIImage {
     public convenience init?(named name: String) {
         let (pathWithoutExtension, fileExtension) = name.pathAndExtension()
 
-        // e.g. ["@3x", "@2x", "@1x", ""]
+        // e.g. ["@3x", "@2x", ""]
         let scale = Int(UIScreen.main.scale.rounded())
-        let possibleScaleStrings = stride(from: scale, through: 1, by: -1)
+        let possibleScaleStrings = stride(from: scale, to: 1, by: -1)
             .map { "@\($0)x" }
             + [""] // it's possible to have no scale string (e.g. "image.png")
 
         for scaleString in possibleScaleStrings {
             let attemptedFilePath = "\(pathWithoutExtension)\(scaleString)\(fileExtension)"
-            if let cgImage = CGImage(GPU_LoadImage(attemptedFilePath)) {
-                let scale = attemptedFilePath.extractImageScale()
-                self.init(cgImage: cgImage, scale: scale)
+            if let data = Data.fromPathCrossPlatform(attemptedFilePath) {
+                self.init(data: data, scale: attemptedFilePath.extractImageScale())
                 return
             }
         }
+
+        print("Couldn't find image named", name)
 
         return nil
     }
 
     public convenience init?(path: String) {
-        guard let cgImage = CGImage(GPU_LoadImage(path)) else { return nil }
-        self.init(cgImage: cgImage, scale: path.extractImageScale())
+        guard let data = Data.fromPathCrossPlatform(path) else { return nil }
+        self.init(data: data, scale: path.extractImageScale())
     }
 
     public convenience init?(data: Data) {
-        var data = data
-        let dataCount = Int32(data.count)
+        self.init(data: data, scale: 1.0) // matches iOS
+    }
 
-        guard let cgImage = data.withUnsafeMutableBytes({ (ptr: UnsafeMutablePointer<Int8>) -> CGImage? in
-            let rw = SDL_RWFromMem(ptr, dataCount)
-            let gpuImagePtr = GPU_LoadImage_RW(rw, true)
-            return CGImage(gpuImagePtr)
-        }) else {
+    private convenience init?(data: Data, scale: CGFloat) {
+        guard let cgImage = CGImage(data) else {
             return nil
         }
 
-        self.init(cgImage: cgImage, scale: 1.0) // matches iOS
+        self.init(cgImage: cgImage, scale: scale)
     }
 }
 

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -67,6 +67,10 @@ open class UILabel: UIView {
         }
     }
 
+    override open func display(_ layer: CALayer) {
+        self.draw()
+    }
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
         isUserInteractionEnabled = false

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -1,0 +1,132 @@
+//
+//  UIScreen+render.swift
+//  UIKit
+//
+//  Created by Chris on 08.08.17.
+//  Copyright © 2017 flowkey. All rights reserved.
+//
+
+import SDL
+import SDL_gpu
+import func Foundation.round
+
+extension UIScreen {
+    func render(window: UIWindow?, atTime frameTimer: Timer) {
+        guard let window = window else {
+            print("Not rendering because `window` was `nil`")
+            return
+        }
+
+        DisplayLink.activeDisplayLinks.forEach { $0.callback() }
+        UIView.animateIfNeeded(at: frameTimer)
+        // XXX: It's possible for drawing to crash if the context is invalid:
+        window.sdlDrawAndLayoutTreeIfNeeded()
+
+        guard CALayer.layerTreeIsDirty else {
+            // Nothing changed, so we can leave the existing image on the screen.
+            return
+        }
+
+        // Layer tree can be made dirty again in layer.sdlRender
+        // So set this here and only reset it if the .flip fails
+        CALayer.layerTreeIsDirty = false
+
+        self.clear()
+        GPU_MatrixMode(GPU_MODELVIEW)
+        GPU_LoadIdentity()
+
+        self.clippingRect = window.bounds
+        window.layer.sdlRender()
+
+        do {
+            try self.flip()
+        } catch {
+            CALayer.layerTreeIsDirty = true
+            assertionFailure("UIScreen failed to render. This shouldn't happen anymore since we added more error handling when rendering the layer tree! Error: \(error)")
+        }
+    }
+
+    func blit(
+        _ image: CGImage,
+        anchorPoint: CGPoint,
+        contentsScale: CGFloat,
+        contentsGravity: ContentsGravityTransformation,
+        opacity: Float
+    ) throws {
+        GPU_SetAnchor(image.rawPointer, Float(anchorPoint.x), Float(anchorPoint.y))
+        GPU_SetRGBA(image.rawPointer, 255, 255, 255, opacity.normalisedToUInt8())
+
+        GPU_BlitTransform(
+            image.rawPointer,
+            nil,
+            self.rawPointer,
+            Float(contentsGravity.offset.x),
+            Float(contentsGravity.offset.y),
+            0, // rotation in degrees
+            Float(contentsGravity.scale.width / contentsScale),
+            Float(contentsGravity.scale.height / contentsScale)
+        )
+
+        try throwOnErrors(ofType: [GPU_ERROR_USER_ERROR])
+    }
+
+    func setShapeBlending(_ newValue: Bool) {
+        GPU_SetShapeBlending(newValue)
+    }
+
+    func setShapeBlendMode(_ newValue: GPU_BlendPresetEnum) {
+        GPU_SetShapeBlendMode(newValue)
+    }
+
+    func clear() {
+        GPU_Clear(rawPointer)
+    }
+
+    func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
+        if cornerRadius >= 1 {
+            GPU_RectangleRoundFilled(rawPointer, rect.gpuRect(scale: scale), cornerRadius: Float(cornerRadius), color: color.sdlColor)
+        } else {
+            GPU_RectangleFilled(rawPointer, rect.gpuRect(scale: scale), color: color.sdlColor)
+        }
+    }
+
+    func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat) {
+        GPU_SetLineThickness(Float(lineThickness))
+        GPU_Rectangle(rawPointer, rect.gpuRect(scale: scale), color: lineColor.sdlColor)
+    }
+
+    func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat, cornerRadius: CGFloat) {
+        if cornerRadius > 1 {
+            GPU_SetLineThickness(Float(lineThickness))
+            GPU_RectangleRound(rawPointer, rect.gpuRect(scale: scale), cornerRadius: Float(cornerRadius), color: lineColor.sdlColor)
+        } else {
+            outline(rect, lineColor: lineColor, lineThickness: lineThickness)
+        }
+    }
+
+    func flip() throws {
+        GPU_Flip(rawPointer)
+        try throwOnErrors(ofType: [GPU_ERROR_USER_ERROR, GPU_ERROR_BACKEND_ERROR])
+    }
+
+    // Called when clippingRect was set.
+    // The function is separated out because that stored property can't be in this extension.
+    func didSetClippingRect() {
+        guard let clippingRect = clippingRect else {
+            return GPU_UnsetClip(rawPointer)
+        }
+
+        GPU_SetClipRect(rawPointer, clippingRect.gpuRect(scale: scale))
+    }
+}
+
+private extension CGRect {
+    func gpuRect(scale: CGFloat) -> GPU_Rect {
+        return GPU_Rect(
+            x: Float(round(self.origin.x * scale) / scale),
+            y: Float(round(self.origin.y * scale) / scale),
+            w: Float(round(self.size.width * scale) / scale),
+            h: Float(round(self.size.height * scale) / scale)
+        )
+    }
+}

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -100,8 +100,6 @@ public final class UIScreen {
         setShapeBlendMode(GPU_BLEND_NORMAL_FACTOR_ALPHA)
 
         clearErrors() // by now we have handled any errors we might have wanted to
-
-        UIFont.loadSystemFonts()
     }
 
     deinit {

--- a/Sources/UIView+SDL.swift
+++ b/Sources/UIView+SDL.swift
@@ -15,6 +15,11 @@ extension UIView {
         let alpha = CGFloat(visibleLayer.opacity) * parentAlpha
         if visibleLayer.isHidden || alpha < 0.01 { return }
 
+        if visibleLayer._needsDisplay {
+            visibleLayer.display()
+            visibleLayer._needsDisplay = false
+        }
+
         if needsDisplay {
             draw()
             needsDisplay = false

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -13,7 +13,7 @@ open class UIView: UIResponder, CALayerDelegate {
         return CALayer.self
     }
 
-    open let layer: CALayer
+    public let layer: CALayer
 
     open var frame: CGRect {
         get { return layer.frame }
@@ -50,7 +50,7 @@ open class UIView: UIResponder, CALayerDelegate {
         }
     }
 
-    open let safeAreaInsets: UIEdgeInsets = .zero
+    public internal(set) var safeAreaInsets: UIEdgeInsets = .zero
 
     open var mask: UIView? {
         didSet {
@@ -78,9 +78,8 @@ open class UIView: UIResponder, CALayerDelegate {
     internal var needsDisplay = true
 
     /// Override this to draw to the layer's texture whenever `self.needsDisplay`
-    open func draw() {
-        needsDisplay = false
-    }
+    open func draw() {}
+    open func display(_ layer: CALayer) {}
 
     public func setNeedsDisplay() {
         needsDisplay = true
@@ -384,4 +383,3 @@ extension UIView: Hashable {
         return ObjectIdentifier(self).hashValue
     }
 }
-

--- a/Sources/VideoTexture+Mac.swift
+++ b/Sources/VideoTexture+Mac.swift
@@ -12,7 +12,7 @@ import SDL_gpu
 
 internal final class VideoTexture: CGImage {
     convenience init?(width: Int, height: Int, format: GPU_FormatEnum) {
-        self.init(GPU_CreateImage(UInt16(width), UInt16(height), format))
+        self.init(GPU_CreateImage(UInt16(width), UInt16(height), format), sourceData: nil)
     }
 }
 

--- a/Sources/androidNativeInit.swift
+++ b/Sources/androidNativeInit.swift
@@ -10,8 +10,8 @@ import SDL
 import CJNI
 
 public struct UIKitAndroid {
-    public static var UIApplicationClass: UIApplication.Type?
     public static var UIApplicationDelegateClass: UIApplicationDelegate.Type?
+    public static var UIApplicationClass: UIApplication.Type = UIApplication.self
 }
 
 @_silgen_name("SDL_Android_Init")
@@ -22,13 +22,17 @@ public func nativeInit(env: UnsafeMutablePointer<JNIEnv>, view: JavaObject) -> J
     SDL_Android_Init(env, view)
     SDL_SetMainReady()
 
-    if UIApplication.shared != nil {
-        return 0 // already inited
+    if UIScreen.main == nil {
+        UIScreen.main = UIScreen()
     }
 
-    return JavaInt(
-        UIApplicationMain(UIKitAndroid.UIApplicationClass, UIKitAndroid.UIApplicationDelegateClass)
-    )
+    if UIApplication.shared == nil {
+        return JavaInt(
+            UIApplicationMain(UIKitAndroid.UIApplicationClass, UIKitAndroid.UIApplicationDelegateClass)
+        )
+    }
+
+    return 0
 }
 
 @_cdecl("Java_org_libsdl_app_SDLActivity_nativeDestroyScreen")

--- a/Sources/androidNativeInit.swift
+++ b/Sources/androidNativeInit.swift
@@ -22,14 +22,15 @@ public func nativeInit(env: UnsafeMutablePointer<JNIEnv>, view: JavaObject) -> J
     SDL_Android_Init(env, view)
     SDL_SetMainReady()
 
-    if UIScreen.main == nil {
-        UIScreen.main = UIScreen()
-    }
-
     if UIApplication.shared == nil {
         return JavaInt(
             UIApplicationMain(UIKitAndroid.UIApplicationClass, UIKitAndroid.UIApplicationDelegateClass)
         )
+    }
+
+    // UIApplicationMain also inits a screen, so this is a special case.
+    if UIScreen.main == nil {
+        UIScreen.main = UIScreen()
     }
 
     return 0

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		5C8E6A21203A089A00D1DBE0 /* CALayer+ContentsGravity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8E6A20203A089A00D1DBE0 /* CALayer+ContentsGravity.swift */; };
 		5C9037211F137FB70058E592 /* CGRectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9037201F137FB70058E592 /* CGRectTests.swift */; };
 		5C9037251F138B8A0058E592 /* MeteringView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C9037241F138B8A0058E592 /* MeteringView.swift */; };
+		5C915950218B6BE300AFEB7E /* Data+fromRelativePathCrossPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C91594F218B6BE300AFEB7E /* Data+fromRelativePathCrossPlatform.swift */; };
+		5C915956218B6C9B00AFEB7E /* UIScreen+render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C915955218B6C9B00AFEB7E /* UIScreen+render.swift */; };
 		5C93AE7C2088F7E7005BE853 /* UINavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C93AE7B2088F7E7005BE853 /* UINavigationController.swift */; };
 		5C93AEA62088FB51005BE853 /* UINavigationBarAndroid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C93AEA52088FB51005BE853 /* UINavigationBarAndroid.swift */; };
 		5C93AEA82088FB70005BE853 /* UINavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C93AEA72088FB70005BE853 /* UINavigationBar.swift */; };
@@ -370,6 +372,8 @@
 		5C8E6A20203A089A00D1DBE0 /* CALayer+ContentsGravity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+ContentsGravity.swift"; sourceTree = "<group>"; };
 		5C9037201F137FB70058E592 /* CGRectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGRectTests.swift; sourceTree = "<group>"; };
 		5C9037241F138B8A0058E592 /* MeteringView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MeteringView.swift; path = Sources/MeteringView.swift; sourceTree = SOURCE_ROOT; };
+		5C91594F218B6BE300AFEB7E /* Data+fromRelativePathCrossPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+fromRelativePathCrossPlatform.swift"; sourceTree = "<group>"; };
+		5C915955218B6C9B00AFEB7E /* UIScreen+render.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+render.swift"; sourceTree = "<group>"; };
 		5C93AE7B2088F7E7005BE853 /* UINavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationController.swift; sourceTree = "<group>"; };
 		5C93AEA52088FB51005BE853 /* UINavigationBarAndroid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationBarAndroid.swift; sourceTree = "<group>"; };
 		5C93AEA72088FB70005BE853 /* UINavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationBar.swift; sourceTree = "<group>"; };
@@ -615,6 +619,7 @@
 				5B115C5C1F61DBF800AAB895 /* UIProgressView.swift */,
 				5C6AB7701ED680BC006F90AC /* UIResponder.swift */,
 				8337A8121F39F37500475F80 /* UIScreen.swift */,
+				5C915955218B6C9B00AFEB7E /* UIScreen+render.swift */,
 				5C6AB75E1ED575CF006F90AC /* UIScrollView.swift */,
 				5CC7463D20BDB286000D21AF /* UIScrollView+indicatorsInternal.swift */,
 				0371D2281F793E5F005DDFED /* UIScrollView+velocity.swift */,
@@ -689,19 +694,20 @@
 		5C27E7F51ECB301900F5020D /* SDL */ = {
 			isa = PBXGroup;
 			children = (
+				8356933B1F8CF6C500C6D253 /* androidNativeInit.swift */,
 				5CDB31B61F1CE8050081A605 /* Bundle.swift */,
 				83F8D4A11F028E6B008D3262 /* CALayer+SDL.swift */,
 				5CDB31B41F1CCA4F0081A605 /* CGDataProvider.swift */,
+				5C91594F218B6BE300AFEB7E /* Data+fromRelativePathCrossPlatform.swift */,
 				5CFBD23D1EF8145C00BC9EBB /* FontRenderer.swift */,
 				5B520DB4208A0AD5007F5075 /* FontRenderer+renderAttributedString.swift */,
 				5CAF5A2F20ADD09500760FD4 /* FontRenderer+singleLineSize.swift */,
 				5CAF2D1D1EE6FD29004C6380 /* Logging.swift */,
 				5C2714A11F2A3FC50026BBA9 /* SDL+JNIExtensions.swift */,
 				5C27E7FC1ECB301900F5020D /* SDL2 Shims.swift */,
-				8356933B1F8CF6C500C6D253 /* androidNativeInit.swift */,
 				5C3716B51F10050600B2C366 /* Timer.swift */,
-				5C361E221ECC348700B3F561 /* UIView+SDL.swift */,
 				5C32F2C320A1C69C006D64C5 /* UIScreen+Errors.swift */,
+				5C361E221ECC348700B3F561 /* UIView+SDL.swift */,
 			);
 			name = SDL;
 			path = Sources;
@@ -1119,6 +1125,7 @@
 				5C93AEB0208A44BC005BE853 /* UIModalPresentationStyle.swift in Sources */,
 				5C6AB71C1ED3BECD006F90AC /* UIImage.swift in Sources */,
 				5C664CD81FA0E640008F41D6 /* ShaderProgram.swift in Sources */,
+				5C915956218B6C9B00AFEB7E /* UIScreen+render.swift in Sources */,
 				5B1F87051F4C889F0051A1A2 /* CAMediaTimingFunction.swift in Sources */,
 				5C6AB7191ED3BECD006F90AC /* CALayer.swift in Sources */,
 				83E5F7F31EF8188400279C59 /* UILabel.swift in Sources */,
@@ -1156,6 +1163,7 @@
 				5CCF1C00201A292400AAF598 /* VideoTexture+Mac.swift in Sources */,
 				5CE5C5711EDC6AA100680154 /* UITapGestureRecognizer.swift in Sources */,
 				5C361E231ECC348700B3F561 /* UIView+SDL.swift in Sources */,
+				5C915950218B6BE300AFEB7E /* Data+fromRelativePathCrossPlatform.swift in Sources */,
 				5B115C5E1F61DBF800AAB895 /* UIProgressView.swift in Sources */,
 				5C9037251F138B8A0058E592 /* MeteringView.swift in Sources */,
 				5C4CD51A206160EC00217B4C /* UIView+printViewHierarchy.swift in Sources */,

--- a/UIKitTests/Texture+Size.swift
+++ b/UIKitTests/Texture+Size.swift
@@ -11,9 +11,10 @@ import SDL_gpu
 
 extension CGImage {
     convenience init?(size: CGSize) {
-        var gpuImage = GPU_Image()
-        gpuImage.w = UInt16(size.width)
-        gpuImage.h = UInt16(size.height)
-        self.init(&gpuImage)
+        // CGImage takes care of deiniting the memory on cleanup so pass this as retained:
+        let pointer = UnsafeMutablePointer<GPU_Image>.allocate(capacity: 1)
+        pointer.pointee.w = UInt16(size.width)
+        pointer.pointee.h = UInt16(size.height)
+        self.init(pointer, sourceData: nil)
     }
 }

--- a/UIKitTests/TransformTests.swift
+++ b/UIKitTests/TransformTests.swift
@@ -117,7 +117,7 @@ class TransformTests: XCTestCase {
         var result = identity
         measure {
             for _ in 0 ..< 1000 {
-                GPU_Multiply4x4(&result, &matrixA, &matrixB)
+                GPU_MatrixMultiply(&result, &matrixA, &matrixB)
                 XCTAssertEqual(result, expectedResult)
             }
         }

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -281,7 +281,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
         }
 
         if (width == 0 || height == 0) {
-            Log.v(TAG, "skipping due to invalid surface dimensions: ${width} x ${height}")
+            Log.v(TAG, "skipping due to invalid surface dimensions: $width x $height")
             return
         }
 


### PR DESCRIPTION
Fixes #208 (and more)

This is a huge improvement to the way rendering works on Android. Until now we had to reload the entire app when the GLContext was killed (as is the case when minimising the app, entering the task switcher etc).

Instead, we now store the image's source data in `CGImage` and use it to re-upload the image data onto the GPU when entering the app again, in the newly recreated GLContext. This means the app and all of its state stays loaded at minimal cost (our PNG sources add up to about 100kb RAM usage). It now looks and feels just like an iOS app 🔥

There are also some related changes to font rendering where statically-stored `UIFont` instances would not render correctly in a newly-created GLContext. `UIFont` is now a little more separated from `FontRenderer`: instead of holding a strong reference to a specific `FontRenderer`, `FontRenderer`s can be recreated behind the scenes and `UIFont` accesses the relevant `FontRenderer` instance dynamically. Aside from the rendering improvements (text stays consistently visible!), this should also fix some crashes when cleaning up fonts.

Finally, we are updating `sdl-gpu` to avoid crashes when "free"ing a GPU_Image that was created in a now-invalid/destroyed `GPU_Renderer` context. This was causing crashes in over 5% of sessions and will be a huge quality of life improvement for Android users.

### Review note:

I tried to make the commit history clean to allow reviewing the different parts of this PR individually, so I can recommend going through each commit one by one.

### Important:

We are now using our own fork of sdl-gpu, so you will probably have to run `git submodule sync` for git to recognise the changed remote.