### PR TITLE
Application state notifications

### DIFF
--- a/Sources/NSNotification.swift
+++ b/Sources/NSNotification.swift
@@ -1,0 +1,10 @@
+//
+//  NSNotification.swift
+//  UIKit
+//
+//  Created by Chetan Agarwal on 29.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+import class Foundation.NSNotification
+public typealias NSNotification = Foundation.NSNotification

--- a/Sources/Notification.swift
+++ b/Sources/Notification.swift
@@ -1,0 +1,10 @@
+//
+//  Notification.swift
+//  UIKit
+//
+//  Created by Chetan Agarwal on 29.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+import struct Foundation.Notification
+public typealias Notification = Foundation.Notification

--- a/Sources/NotificationCenter.swift
+++ b/Sources/NotificationCenter.swift
@@ -1,0 +1,10 @@
+//
+//  NotificationCenter.swift
+//  UIKit
+//
+//  Created by Chetan Agarwal on 29.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+import class Foundation.NotificationCenter
+public typealias NotificationCenter = Foundation.NotificationCenter

--- a/Sources/UIApplication+Notifications.swift
+++ b/Sources/UIApplication+Notifications.swift
@@ -1,0 +1,39 @@
+//
+//  UIApplication+Notifications.swift
+//  UIKit
+//
+//  Created by Chetan Agarwal on 30.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+extension UIApplication {
+    public class var didEnterBackgroundNotification: NSNotification.Name {
+        return NSNotification.Name.UIApplicationDidEnterBackground
+    }
+
+    public class var willEnterForegroundNotification: NSNotification.Name {
+        return NSNotification.Name.UIApplicationWillEnterForeground
+    }
+
+    public class var didBecomeActiveNotification: NSNotification.Name {
+        return NSNotification.Name.UIApplicationDidBecomeActive
+    }
+
+    public class var willResignActiveNotification: NSNotification.Name {
+        return NSNotification.Name.UIApplicationWillResignActive
+    }
+}
+
+extension NSNotification.Name {
+    public static let UIApplicationDidEnterBackground
+        = NSNotification.Name(rawValue: "UIApplicationDidEnterBackgroundNotification")
+
+    public static let UIApplicationWillEnterForeground
+        = NSNotification.Name(rawValue: "UIApplicationWillEnterForegroundNotification")
+
+    public static let UIApplicationDidBecomeActive
+        = NSNotification.Name(rawValue: "UIApplicationDidBecomeActiveNotification")
+
+    public static let UIApplicationWillResignActive
+        = NSNotification.Name(rawValue: "UIApplicationWillResignActiveNotification")
+}

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -101,22 +101,22 @@ extension UIApplication {
         #endif
 
         UIApplication.shared?.delegate?.applicationWillEnterForeground(UIApplication.shared)
-        UIApplication.post(UIApplication.willEnterForegroundNotification)
+        UIApplication.post(willEnterForegroundNotification)
     }
 
     static func onDidEnterForeground() {
         UIApplication.shared?.delegate?.applicationDidBecomeActive(UIApplication.shared)
-        UIApplication.post(UIApplication.didBecomeActiveNotification)
+        UIApplication.post(didBecomeActiveNotification)
     }
 
     static func onWillEnterBackground() {
         UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
-        UIApplication.post(UIApplication.willResignActiveNotification)
+        UIApplication.post(willResignActiveNotification)
     }
 
     static func onDidEnterBackground() {
         UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
-        UIApplication.post(UIApplication.didEnterBackgroundNotification)
+        UIApplication.post(didEnterBackgroundNotification)
 
         #if os(Android)
         UIScreen.main = nil

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -93,7 +93,7 @@ extension UIApplication {
 }
 
 extension UIApplication {
-    static func onWillEnterForeground() {
+    class func onWillEnterForeground() {
         #if os(Android)
         if UIScreen.main == nil { // sometimes we "enter foreground" after just a loss of focus
             UIScreen.main = UIScreen()
@@ -104,17 +104,17 @@ extension UIApplication {
         UIApplication.post(willEnterForegroundNotification)
     }
 
-    static func onDidEnterForeground() {
+    class func onDidEnterForeground() {
         UIApplication.shared?.delegate?.applicationDidBecomeActive(UIApplication.shared)
         UIApplication.post(didBecomeActiveNotification)
     }
 
-    static func onWillEnterBackground() {
+    class func onWillEnterBackground() {
         UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
         UIApplication.post(willResignActiveNotification)
     }
 
-    static func onDidEnterBackground() {
+    class func onDidEnterBackground() {
         UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
         UIApplication.post(didEnterBackgroundNotification)
 
@@ -125,7 +125,7 @@ extension UIApplication {
 }
 
 private extension UIApplication {
-    static func post(_ name: NSNotification.Name) {
+    class func post(_ name: NSNotification.Name) {
         NotificationCenter.default.post(name: name, object: UIApplication.shared)
     }
 }

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -101,22 +101,32 @@ extension UIApplication {
         #endif
 
         UIApplication.shared?.delegate?.applicationWillEnterForeground(UIApplication.shared)
+        UIApplication.shared?.post(UIApplication.willEnterForegroundNotification)
     }
 
     static func onDidEnterForeground() {
         UIApplication.shared?.delegate?.applicationDidBecomeActive(UIApplication.shared)
+        UIApplication.shared?.post(UIApplication.didBecomeActiveNotification)
     }
 
     static func onWillEnterBackground() {
         UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
+        UIApplication.shared?.post(UIApplication.willResignActiveNotification)
     }
 
     static func onDidEnterBackground() {
         UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
+        UIApplication.shared?.post(UIApplication.didEnterBackgroundNotification)
 
         #if os(Android)
         UIScreen.main = nil
         #endif
+    }
+}
+
+private extension UIApplication {
+    func post(_ name: NSNotification.Name) {
+        NotificationCenter.default.post(name: name, object: self)
     }
 }
 

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -101,22 +101,22 @@ extension UIApplication {
         #endif
 
         UIApplication.shared?.delegate?.applicationWillEnterForeground(UIApplication.shared)
-        UIApplication.shared?.post(UIApplication.willEnterForegroundNotification)
+        UIApplication.post(UIApplication.willEnterForegroundNotification)
     }
 
     static func onDidEnterForeground() {
         UIApplication.shared?.delegate?.applicationDidBecomeActive(UIApplication.shared)
-        UIApplication.shared?.post(UIApplication.didBecomeActiveNotification)
+        UIApplication.post(UIApplication.didBecomeActiveNotification)
     }
 
     static func onWillEnterBackground() {
         UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
-        UIApplication.shared?.post(UIApplication.willResignActiveNotification)
+        UIApplication.post(UIApplication.willResignActiveNotification)
     }
 
     static func onDidEnterBackground() {
         UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
-        UIApplication.shared?.post(UIApplication.didEnterBackgroundNotification)
+        UIApplication.post(UIApplication.didEnterBackgroundNotification)
 
         #if os(Android)
         UIScreen.main = nil
@@ -125,8 +125,8 @@ extension UIApplication {
 }
 
 private extension UIApplication {
-    func post(_ name: NSNotification.Name) {
-        NotificationCenter.default.post(name: name, object: self)
+    static func post(_ name: NSNotification.Name) {
+        NotificationCenter.default.post(name: name, object: UIApplication.shared)
     }
 }
 

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -97,33 +97,3 @@ public func nativeProcessEventsAndRender(env: UnsafeMutablePointer<JNIEnv>, view
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 2), true)
 }
 #endif
-
-extension UIApplication {
-    public static let didEnterBackgroundNotification
-        = NSNotification.Name.UIApplicationDidEnterBackground
-
-    public static let willEnterForegroundNotification
-        = NSNotification.Name.UIApplicationWillEnterForeground
-
-
-    public static let didBecomeActiveNotification
-        = NSNotification.Name.UIApplicationDidBecomeActive
-
-
-    public static let willResignActiveNotification
-        = NSNotification.Name.UIApplicationWillResignActive
-}
-
-extension NSNotification.Name {
-    public static let UIApplicationDidEnterBackground
-        = NSNotification.Name(rawValue: "UIApplicationDidEnterBackgroundNotification")
-
-    public static let UIApplicationWillEnterForeground
-        = NSNotification.Name(rawValue: "UIApplicationWillEnterForegroundNotification")
-
-    public static let UIApplicationDidBecomeActive
-        = NSNotification.Name(rawValue: "UIApplicationDidBecomeActiveNotification")
-
-    public static let UIApplicationWillResignActive
-        = NSNotification.Name(rawValue: "UIApplicationWillResignActiveNotification")
-}

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -97,3 +97,33 @@ public func nativeProcessEventsAndRender(env: UnsafeMutablePointer<JNIEnv>, view
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 2), true)
 }
 #endif
+
+extension UIApplication {
+    public static let didEnterBackgroundNotification
+        = NSNotification.Name.UIApplicationDidEnterBackground
+
+    public static let willEnterForegroundNotification
+        = NSNotification.Name.UIApplicationWillEnterForeground
+
+
+    public static let didBecomeActiveNotification
+        = NSNotification.Name.UIApplicationDidBecomeActive
+
+
+    public static let willResignActiveNotification
+        = NSNotification.Name.UIApplicationWillResignActive
+}
+
+extension NSNotification.Name {
+    public static let UIApplicationDidEnterBackground
+        = NSNotification.Name(rawValue: "UIApplicationDidEnterBackgroundNotification")
+
+    public static let UIApplicationWillEnterForeground
+        = NSNotification.Name(rawValue: "UIApplicationWillEnterForegroundNotification")
+
+    public static let UIApplicationDidBecomeActive
+        = NSNotification.Name(rawValue: "UIApplicationDidBecomeActiveNotification")
+
+    public static let UIApplicationWillResignActive
+        = NSNotification.Name(rawValue: "UIApplicationWillResignActiveNotification")
+}

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -130,6 +130,9 @@
 		5CFBD23E1EF8145C00BC9EBB /* FontRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFBD23D1EF8145C00BC9EBB /* FontRenderer.swift */; };
 		5CFFFA172017457100D989BC /* UIViewTests+subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFFFA162017457100D989BC /* UIViewTests+subviews.swift */; };
 		5CFFFA182017457100D989BC /* UIViewTests+subviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CFFFA162017457100D989BC /* UIViewTests+subviews.swift */; };
+		61C9D3B121B051B10012018B /* NSNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3B021B051B10012018B /* NSNotification.swift */; };
+		61C9D3B921B052750012018B /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3B821B052750012018B /* Notification.swift */; };
+		61C9D3BB21B052B30012018B /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3BA21B052B30012018B /* NotificationCenter.swift */; };
 		8318D27B1F0695080029816A /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8318D27A1F0695080029816A /* UIControl.swift */; };
 		8323F2801F2FA2EE00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
 		8323F2821F2FA42A00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
@@ -414,6 +417,9 @@
 		5CFFF87F201632FC00D989BC /* SDL-gpu.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "SDL-gpu.xcodeproj"; path = "SDL/SDL-gpu.xcodeproj"; sourceTree = "<group>"; };
 		5CFFF97C20163AF900D989BC /* SDL_ttf.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SDL_ttf.xcodeproj; path = SDL/SDL_ttf.xcodeproj; sourceTree = "<group>"; };
 		5CFFFA162017457100D989BC /* UIViewTests+subviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewTests+subviews.swift"; sourceTree = "<group>"; };
+		61C9D3B021B051B10012018B /* NSNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotification.swift; sourceTree = "<group>"; };
+		61C9D3B821B052750012018B /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
+		61C9D3BA21B052B30012018B /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
 		83023EC71F9E31D400389F89 /* VideoTexture+Mac.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoTexture+Mac.swift"; sourceTree = "<group>"; };
 		8318D27A1F0695080029816A /* UIControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIControl.swift; path = ../Sources/UIControl.swift; sourceTree = "<group>"; };
 		8323F27F1F2FA2EE00C121BB /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
@@ -592,9 +598,12 @@
 				83E5F7FF1EF826CC00279C59 /* Geometry */,
 				5BD476341F4D94F40055EE27 /* Logging.swift */,
 				5C9037241F138B8A0058E592 /* MeteringView.swift */,
+				61C9D3B821B052750012018B /* Notification.swift */,
+				61C9D3BA21B052B30012018B /* NotificationCenter.swift */,
 				8333B2BF1F1D11B800D98662 /* NSAttributedString.swift */,
 				838545711F26536200B64986 /* NSAttributedStringKey.swift */,
 				83D961341F2635D5005176DC /* NSMutableAttributedString.swift */,
+				61C9D3B021B051B10012018B /* NSNotification.swift */,
 				83CC3CD01F275DB600144E85 /* NSRange.swift */,
 				8337A8581F3B143400475F80 /* UIActivityIndicatorView.swift */,
 				83AB7B4B1F2B515B00C7997D /* UIAlertAction.swift */,
@@ -1126,6 +1135,7 @@
 				5C6AB71C1ED3BECD006F90AC /* UIImage.swift in Sources */,
 				5C664CD81FA0E640008F41D6 /* ShaderProgram.swift in Sources */,
 				5C915956218B6C9B00AFEB7E /* UIScreen+render.swift in Sources */,
+				61C9D3B921B052750012018B /* Notification.swift in Sources */,
 				5B1F87051F4C889F0051A1A2 /* CAMediaTimingFunction.swift in Sources */,
 				5C6AB7191ED3BECD006F90AC /* CALayer.swift in Sources */,
 				83E5F7F31EF8188400279C59 /* UILabel.swift in Sources */,
@@ -1144,6 +1154,7 @@
 				5BBEECA51F39E7A6006E3416 /* CGRect+animations.swift in Sources */,
 				5CDC14CC1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift in Sources */,
 				5BC6F7A81F4B1A3600F9C432 /* CABasicAnimation+updateProgress.swift in Sources */,
+				61C9D3B121B051B10012018B /* NSNotification.swift in Sources */,
 				83AB7B5C1F2B6A2000C7997D /* UIGestureRecognizerDelegate.swift in Sources */,
 				838545721F26536200B64986 /* NSAttributedStringKey.swift in Sources */,
 				5C6AB7611ED5762A006F90AC /* UIEdgeInsets.swift in Sources */,
@@ -1203,6 +1214,7 @@
 				5C3716B61F10050600B2C366 /* Timer.swift in Sources */,
 				5CAF2D0C1EE67D69004C6380 /* CABasicAnimation.swift in Sources */,
 				5C3DCCEF2090F072001DEDAF /* UIAlertControllerView.swift in Sources */,
+				61C9D3BB21B052B30012018B /* NotificationCenter.swift in Sources */,
 				5CE5C5781EDDAD8200680154 /* CGRect.swift in Sources */,
 				5C32F2C420A1C69C006D64C5 /* UIScreen+Errors.swift in Sources */,
 				0371D2291F793E5F005DDFED /* UIScrollView+velocity.swift in Sources */,

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		61C9D3B121B051B10012018B /* NSNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3B021B051B10012018B /* NSNotification.swift */; };
 		61C9D3B921B052750012018B /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3B821B052750012018B /* Notification.swift */; };
 		61C9D3BB21B052B30012018B /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3BA21B052B30012018B /* NotificationCenter.swift */; };
+		61EE7A1821B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EE7A1721B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift */; };
 		8318D27B1F0695080029816A /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8318D27A1F0695080029816A /* UIControl.swift */; };
 		8323F2801F2FA2EE00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
 		8323F2821F2FA42A00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
@@ -420,6 +421,7 @@
 		61C9D3B021B051B10012018B /* NSNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSNotification.swift; sourceTree = "<group>"; };
 		61C9D3B821B052750012018B /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		61C9D3BA21B052B30012018B /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
+		61EE7A1721B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+NSNotificationTests.swift"; sourceTree = "<group>"; };
 		83023EC71F9E31D400389F89 /* VideoTexture+Mac.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoTexture+Mac.swift"; sourceTree = "<group>"; };
 		8318D27A1F0695080029816A /* UIControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIControl.swift; path = ../Sources/UIControl.swift; sourceTree = "<group>"; };
 		8323F27F1F2FA2EE00C121BB /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
@@ -669,6 +671,7 @@
 				03760AE51F67E73300F36283 /* UIScrollViewTests.swift */,
 				5CFFFA0E2017454300D989BC /* UIView */,
 				5C93AEB5208E09B5005BE853 /* UIViewControllerTests.swift */,
+				61EE7A1721B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift */,
 			);
 			path = UIKitTests;
 			sourceTree = "<group>";
@@ -1234,6 +1237,7 @@
 				83F02DBD1F179D1A00347AA8 /* ButtonSetTitleForStateTests.swift in Sources */,
 				03C4872A1F750C8D004BAA0C /* UIPanGestureRecognizerTests.swift in Sources */,
 				5BD4762E1F4D82070055EE27 /* CAMediaTimingFunctionTests.swift in Sources */,
+				61EE7A1821B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift in Sources */,
 				5CB6E1C02031ECCE001FEAC9 /* TransformTests.swift in Sources */,
 				034898331FB5C11F00E8975C /* UITouchTests.swift in Sources */,
 				5CFFFA172017457100D989BC /* UIViewTests+subviews.swift in Sources */,

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		61C9D3B921B052750012018B /* Notification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3B821B052750012018B /* Notification.swift */; };
 		61C9D3BB21B052B30012018B /* NotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C9D3BA21B052B30012018B /* NotificationCenter.swift */; };
 		61EE7A1821B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EE7A1721B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift */; };
+		61EE7A2E21B18940003A5FFD /* UIApplication+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EE7A2D21B18940003A5FFD /* UIApplication+Notifications.swift */; };
 		8318D27B1F0695080029816A /* UIControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8318D27A1F0695080029816A /* UIControl.swift */; };
 		8323F2801F2FA2EE00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
 		8323F2821F2FA42A00C121BB /* TestSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8323F27F1F2FA2EE00C121BB /* TestSetup.swift */; };
@@ -422,6 +423,7 @@
 		61C9D3B821B052750012018B /* Notification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.swift; sourceTree = "<group>"; };
 		61C9D3BA21B052B30012018B /* NotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenter.swift; sourceTree = "<group>"; };
 		61EE7A1721B15BC9003A5FFD /* UIApplication+NSNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+NSNotificationTests.swift"; sourceTree = "<group>"; };
+		61EE7A2D21B18940003A5FFD /* UIApplication+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Notifications.swift"; sourceTree = "<group>"; };
 		83023EC71F9E31D400389F89 /* VideoTexture+Mac.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VideoTexture+Mac.swift"; sourceTree = "<group>"; };
 		8318D27A1F0695080029816A /* UIControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIControl.swift; path = ../Sources/UIControl.swift; sourceTree = "<group>"; };
 		8323F27F1F2FA2EE00C121BB /* TestSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSetup.swift; sourceTree = "<group>"; };
@@ -611,6 +613,7 @@
 				83AB7B4B1F2B515B00C7997D /* UIAlertAction.swift */,
 				5C3DCCED2090F04A001DEDAF /* UIAlertController */,
 				5C418DBF20F507DA005D0E92 /* UIApplication.swift */,
+				61EE7A2D21B18940003A5FFD /* UIApplication+Notifications.swift */,
 				5CBD836020F6584200AF4E8E /* UIApplicationMain.swift */,
 				5C418DC120F5149E005D0E92 /* UIApplicationMain+Mac.swift */,
 				5C4CD51020615FCF00217B4C /* UIApplication+handleSDLEvents.swift */,
@@ -1193,6 +1196,7 @@
 				5C418DC220F5149E005D0E92 /* UIApplicationMain+Mac.swift in Sources */,
 				5BD3D1F31F5979E0007671D4 /* AnimationKeyPath.swift in Sources */,
 				83E5F7EB1EF8156400279C59 /* CGImage.swift in Sources */,
+				61EE7A2E21B18940003A5FFD /* UIApplication+Notifications.swift in Sources */,
 				5C6AB75F1ED575CF006F90AC /* UIScrollView.swift in Sources */,
 				5CDB31B71F1CE8050081A605 /* Bundle.swift in Sources */,
 				8378E17E1F05503600E138BD /* UIVisualEffectView.swift in Sources */,

--- a/UIKitTests/UIApplication+NSNotificationTests.swift
+++ b/UIKitTests/UIApplication+NSNotificationTests.swift
@@ -13,25 +13,25 @@ class UIApplication_NSNotificationTests: XCTestCase {
     func testApplicationPostsWillEnterForegroundNotification() {
         expectation(forNotification: .UIApplicationWillEnterForeground, object: nil, handler: nil)
         UIApplication.onWillEnterForeground()
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 0)
     }
 
     func testApplicationPostsDidBecomeActiveNotification() {
         expectation(forNotification: .UIApplicationDidBecomeActive, object: nil, handler: nil)
         UIApplication.onDidEnterForeground()
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 0)
     }
 
     func testApplicationPostsWillResignActiveNotification() {
         expectation(forNotification: .UIApplicationWillResignActive, object: nil, handler: nil)
         UIApplication.onWillEnterBackground()
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 0)
     }
 
     func testApplicationPostsDidEnterBackgroundNotification() {
         expectation(forNotification: .UIApplicationDidEnterBackground, object: nil, handler: nil)
         UIApplication.onDidEnterBackground()
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 0)
     }
 }
 

--- a/UIKitTests/UIApplication+NSNotificationTests.swift
+++ b/UIKitTests/UIApplication+NSNotificationTests.swift
@@ -1,0 +1,45 @@
+//
+//  UIApplication+NSNotificationTests.swift
+//  UIKitTests
+//
+//  Created by Chetan Agarwal on 30.11.18.
+//  Copyright © 2018 flowkey. All rights reserved.
+//
+
+import XCTest
+@testable import UIKit
+
+class UIApplication_NSNotificationTests: XCTestCase {
+    func testApplicationPostsWillEnterForegroundNotification() {
+        let notificationExpectation = expectation(forNotification: .UIApplicationWillEnterForeground,
+                                                  object: nil,
+                                                  handler: nil)
+        UIApplication.onWillEnterForeground()
+        wait(for: [notificationExpectation], timeout: 0.1)
+    }
+
+    func testApplicationPostsDidBecomeActiveNotification() {
+        let notificationExpectation = expectation(forNotification: .UIApplicationDidBecomeActive,
+                                                  object: nil,
+                                                  handler: nil)
+        UIApplication.onDidEnterForeground()
+        wait(for: [notificationExpectation], timeout: 0.1)
+    }
+
+    func testApplicationPostsWillResignActiveNotification() {
+        let notificationExpectation = expectation(forNotification: .UIApplicationWillResignActive,
+                                                  object: nil,
+                                                  handler: nil)
+        UIApplication.onWillEnterBackground()
+        wait(for: [notificationExpectation], timeout: 0.1)
+    }
+
+    func testApplicationPostsDidEnterBackgroundNotification() {
+        let notificationExpectation = expectation(forNotification: .UIApplicationDidEnterBackground,
+                                                  object: nil,
+                                                  handler: nil)
+        UIApplication.onDidEnterBackground()
+        wait(for: [notificationExpectation], timeout: 0.1)
+    }
+}
+

--- a/UIKitTests/UIApplication+NSNotificationTests.swift
+++ b/UIKitTests/UIApplication+NSNotificationTests.swift
@@ -11,35 +11,27 @@ import XCTest
 
 class UIApplication_NSNotificationTests: XCTestCase {
     func testApplicationPostsWillEnterForegroundNotification() {
-        let notificationExpectation = expectation(forNotification: .UIApplicationWillEnterForeground,
-                                                  object: nil,
-                                                  handler: nil)
+        expectation(forNotification: .UIApplicationWillEnterForeground, object: nil, handler: nil)
         UIApplication.onWillEnterForeground()
-        wait(for: [notificationExpectation], timeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
     func testApplicationPostsDidBecomeActiveNotification() {
-        let notificationExpectation = expectation(forNotification: .UIApplicationDidBecomeActive,
-                                                  object: nil,
-                                                  handler: nil)
+        expectation(forNotification: .UIApplicationDidBecomeActive, object: nil, handler: nil)
         UIApplication.onDidEnterForeground()
-        wait(for: [notificationExpectation], timeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
     func testApplicationPostsWillResignActiveNotification() {
-        let notificationExpectation = expectation(forNotification: .UIApplicationWillResignActive,
-                                                  object: nil,
-                                                  handler: nil)
+        expectation(forNotification: .UIApplicationWillResignActive, object: nil, handler: nil)
         UIApplication.onWillEnterBackground()
-        wait(for: [notificationExpectation], timeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 
     func testApplicationPostsDidEnterBackgroundNotification() {
-        let notificationExpectation = expectation(forNotification: .UIApplicationDidEnterBackground,
-                                                  object: nil,
-                                                  handler: nil)
+        expectation(forNotification: .UIApplicationDidEnterBackground, object: nil, handler: nil)
         UIApplication.onDidEnterBackground()
-        wait(for: [notificationExpectation], timeout: 0.1)
+        waitForExpectations(timeout: 0.1)
     }
 }
 


### PR DESCRIPTION
Implements #271 

**Type of change:** Feature

## Motivation (current vs expected behavior)
iOS provides application state change notifications via `NotificationCenter`, which can be useful.
Also, including the `NotificationCenter` and related types, it becomes possible for developers to add and post their own custom notifications in their apps.


## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [x] Tests for the changes have been added (for bug fixes / features)
