### PR TITLE
Only delete CGImage contents if we have no source data

### DIFF
--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -112,11 +112,14 @@ extension CALayer {
                     opacity: opacity
                 )
             } catch {
-                // Try to recreate contents from source data if it exists
-                if contents.reloadFromSourceData() == false {
-                    // That failed, rely on the layer to re-render itself:
+                if !contents.hasSourceData {
                     self.contents = nil
                     self.setNeedsDisplay()
+                } else {
+                    // Try to recreate contents from source data if it exists
+                    if contents.reloadFromSourceData() == false {
+                        // we don't want this to happen because it wastes CPU time, but juckt
+                    }
                 }
             }
         }

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -113,7 +113,6 @@ extension CALayer {
                 )
             } catch {
                 if !contents.hasSourceData {
-                    self.contents = nil
                     self.setNeedsDisplay()
                 } else {
                     // Try to recreate contents from source data if it exists

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -70,6 +70,8 @@ public class CGImage {
         GPU_UpdateImageBytes(rawPointer, &rect, bytes, Int32(rawPointer.pointee.w) * Int32(bytesPerPixel))
     }
 
+    internal var hasSourceData: Bool { return sourceData != nil }
+
     /// Recreate the underlying `GPU_Image` (`self.rawPointer`) from this `CGImage`'s source data if possible.
     /// - Returns: `true`, if it was possible to recreate the image. Or `false`, if there was no underlying source data, or when SDL_gpu could not decode that data.
     internal func reloadFromSourceData() -> Bool {

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -112,15 +112,15 @@ extension UIApplication {
     class func onWillEnterBackground() {
         UIApplication.shared?.delegate?.applicationWillResignActive(UIApplication.shared)
         UIApplication.post(willResignActiveNotification)
+
+        #if os(Android)
+        UIScreen.main = nil
+        #endif
     }
 
     class func onDidEnterBackground() {
         UIApplication.shared?.delegate?.applicationDidEnterBackground(UIApplication.shared)
         UIApplication.post(didEnterBackgroundNotification)
-
-        #if os(Android)
-        UIScreen.main = nil
-        #endif
     }
 }
 


### PR DESCRIPTION
## Motivation (current vs expected behavior)

If we try to render in the background we are likely to falsely set various `CGImage.contents` to `nil`. This shouldn't happen.