### PR TITLE
Fix UIImage Size

### DIFF
--- a/Sources/UIImage.swift
+++ b/Sources/UIImage.swift
@@ -19,8 +19,8 @@ public class UIImage {
         self.cgImage = cgImage
         self.scale = scale
         self.size = CGSize(
-            width: CGFloat(cgImage.width),
-            height: CGFloat(cgImage.height)
+            width: CGFloat(cgImage.width) / scale,
+            height: CGFloat(cgImage.height) / scale
         )
     }
 

--- a/Sources/UIImageView.swift
+++ b/Sources/UIImageView.swift
@@ -22,7 +22,7 @@ open class UIImageView: UIView {
         layer.contents = image?.cgImage
         layer.contentsScale = image?.scale ?? UIScreen.main.scale
         if let image = image {
-            bounds.size = image.size / image.scale
+            bounds.size = image.size
         }
     }
 
@@ -35,8 +35,7 @@ open class UIImageView: UIView {
     }
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
-        guard let image = image else { return .zero }
-        return image.size / image.scale
+        return image?.size ?? .zero
     }
 
     open var contentMode: UIContentMode = .scaleToFill {


### PR DESCRIPTION
The current code has correct behaviour when displaying images with various scale factors, but fails when programmatically relying on the size of a `UIImage` (which is e.g. 2x too big when `scale == 2`).