### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# We use codeowners to protect critical code. In order to change those parts of the code
+# a review from at least one "owner" is required.
+
+Sources/CALayer+SDL.swift @ephemer
+Sources/UIView+SDL.swift @ephemer
+Sources/FontRender*.swift @ephemer
+Sources/Shader*.swift @ephemer
+


### PR DESCRIPTION
**Type of change:** Dev workflows<!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)

We want to use codeowners to protect critical code. In order to change those parts of the code
a review from at least one "owner" is required.
We don't want to introduce unnecessary overheaded by defining overall codeowners. At some point in the future (once the team grows) we might add this for additional safety.

Once this PR is merged we will add the following branch protection rule for master:
<img width="584" alt="image" src="https://user-images.githubusercontent.com/10008938/56563990-6208c400-65ad-11e9-8ead-776c4f4115a8.png">

## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
