### PR TITLE
add stub for UIAccessibilityIdentification

### DIFF
--- a/Sources/UIAccessibilityIdentification.swift
+++ b/Sources/UIAccessibilityIdentification.swift
@@ -1,0 +1,4 @@
+
+public protocol UIAccessibilityIdentification {
+    var accessibilityIdentifier: String? { get set }
+}

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -8,7 +8,9 @@
 
 import SDL
 
-open class UIView: UIResponder, CALayerDelegate {
+open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
+    open var accessibilityIdentifier: String?
+
     open class var layerClass: CALayer.Type {
         return CALayer.self
     }

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -9,8 +9,6 @@
 import SDL
 
 open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
-    open var accessibilityIdentifier: String?
-
     open class var layerClass: CALayer.Type {
         return CALayer.self
     }
@@ -360,6 +358,9 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
         return nil
     }
+
+    // MARK: Accessibility
+    open var accessibilityIdentifier: String?
 }
 
 extension UIView: CustomStringConvertible {

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		5B4F43CF1F39C45900FB4AB9 /* CASpringAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F43CE1F39C45900FB4AB9 /* CASpringAnimation.swift */; };
 		5B520DB5208A0AD5007F5075 /* FontRenderer+renderAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B520DB4208A0AD5007F5075 /* FontRenderer+renderAttributedString.swift */; };
 		5B6AC4571F2F73A90029AC0C /* CALayer+animations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B6AC4561F2F73A90029AC0C /* CALayer+animations.swift */; };
+		5B71D7472292B68E008CEC66 /* UIAccessibilityIdentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B71D7462292B68E008CEC66 /* UIAccessibilityIdentification.swift */; };
 		5B8053DF1F39EE0E00BAF074 /* UIViewAnimationGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8053DE1F39EE0E00BAF074 /* UIViewAnimationGroup.swift */; };
 		5B840BB71F42FCBD0010AC95 /* AnimatableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B840BB61F42FCBC0010AC95 /* AnimatableProperty.swift */; };
 		5BA1FC4E1F6694CA005843B9 /* UITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA1FC4D1F6694CA005843B9 /* UITextView.swift */; };
@@ -305,6 +306,7 @@
 		5B4F43CE1F39C45900FB4AB9 /* CASpringAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CASpringAnimation.swift; path = Sources/CASpringAnimation.swift; sourceTree = SOURCE_ROOT; };
 		5B520DB4208A0AD5007F5075 /* FontRenderer+renderAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FontRenderer+renderAttributedString.swift"; sourceTree = "<group>"; };
 		5B6AC4561F2F73A90029AC0C /* CALayer+animations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CALayer+animations.swift"; path = "Sources/CALayer+animations.swift"; sourceTree = SOURCE_ROOT; };
+		5B71D7462292B68E008CEC66 /* UIAccessibilityIdentification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityIdentification.swift; sourceTree = "<group>"; };
 		5B8053DE1F39EE0E00BAF074 /* UIViewAnimationGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIViewAnimationGroup.swift; path = Sources/UIViewAnimationGroup.swift; sourceTree = SOURCE_ROOT; };
 		5B840BB61F42FCBC0010AC95 /* AnimatableProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AnimatableProperty.swift; path = Sources/AnimatableProperty.swift; sourceTree = SOURCE_ROOT; };
 		5BA1FC4D1F6694CA005843B9 /* UITextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UITextView.swift; path = Sources/UITextView.swift; sourceTree = SOURCE_ROOT; };
@@ -643,6 +645,7 @@
 				5C6AB7161ED3BECD006F90AC /* UIView.swift */,
 				5C6AB76A1ED5A648006F90AC /* UIView+animate.swift */,
 				5C4CD519206160EC00217B4C /* UIView+printViewHierarchy.swift */,
+				5B71D7462292B68E008CEC66 /* UIAccessibilityIdentification.swift */,
 				5C93AE842088F7FA005BE853 /* UIViewController */,
 				838545621F26458100B64986 /* UIVisualEffect.swift */,
 				8378E17D1F05503600E138BD /* UIVisualEffectView.swift */,
@@ -1159,6 +1162,7 @@
 				83E5F8171EF8322E00279C59 /* CGFloat.swift in Sources */,
 				5C6AB71D1ED3BECD006F90AC /* UIImageView.swift in Sources */,
 				5BBEECA51F39E7A6006E3416 /* CGRect+animations.swift in Sources */,
+				5B71D7472292B68E008CEC66 /* UIAccessibilityIdentification.swift in Sources */,
 				5CDC14CC1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift in Sources */,
 				5BC6F7A81F4B1A3600F9C432 /* CABasicAnimation+updateProgress.swift in Sources */,
 				61C9D3B121B051B10012018B /* NSNotification.swift in Sources */,


### PR DESCRIPTION
**Type of change:** stubbed feature

## Motivation (current vs expected behavior)
Implement protocol UIAccessibilityIdentification with stubbed type `accessibilityIdentifier: String?`


## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
