### PR TITLE
remove unneeded support library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.google.android.exoplayer:exoplayer:2.9.3"
 }

--- a/samples/getting-started/android/app/build.gradle
+++ b/samples/getting-started/android/app/build.gradle
@@ -29,6 +29,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:28.0.0'
     api project(":uikit")
 }


### PR DESCRIPTION
**Type of change:** cleanup

## Motivation (current vs expected behavior)
Support library is not used at all, removing it might fix androidx/support issues in parent projects.



## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
