### PR TITLE
Replace slack link with spectrum

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For additional information please refer to our [contribution guidelines](docs/CO
 
 [Our FAQs can be found here (*Work In Progress*)](docs/FAQs.md).
 
-Please contact us regarding upcoming issues on [Slack](http://bit.ly/uikit-cross-platform) or create a new [Issue](https://github.com/flowkey/UIKit-cross-platform/issues/new/choose).
+Please contact us regarding upcoming issues on [Spectrum](https://spectrum.chat/uikit-cross-platform) or create a new [Issue](https://github.com/flowkey/UIKit-cross-platform/issues/new/choose).
 
 ## License
 


### PR DESCRIPTION
**Type of change:** Docs / community <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)

[As discussed in slack](https://uikit-cross-platform.slack.com/archives/CBRJSDK2Q/p1555447288001600), it's easier to join a spectrum community than a slack workspace for questions/feedback.
