### PR TITLE
fix 'create-android-project' and enhance readme

### DIFF
--- a/create-android-project
+++ b/create-android-project
@@ -33,7 +33,7 @@ cp "${TEMPLATE_PATH}/CMakeLists.txt" .
 
 
 echo "Creating ${TARGET_SOURCES_DIRECTORY}/androidMain.swift with UIApplicationDelegate class 'AppDelegate'"
-cp "${TEMPLATE_PATH}/DemoApp/androidMain.swift" "$TARGET_SOURCES_DIRECTORY"
+cp "${TEMPLATE_PATH}/DemoApp/androidMain.swift" "$TARGET_SOURCES_DIRECTORY"/
 
 cp -R "${TEMPLATE_PATH}/android" .
 rm -rf ${IOS_PROJECT_DIR}/android/{.idea,.gradle,build,android.iml,app/{.externalNativeBuild,build}}
@@ -62,9 +62,9 @@ do
 done
 
 # adjust path to UIKit
-sed -i '' "s~../../../~../UIKit~g" ${IOS_PROJECT_DIR}/android/settings.gradle
-sed -i '' "s~../../~./UIKit~g" ${IOS_PROJECT_DIR}/CMakeLists.txt
-sed -i '' "s~../../../../~../../UIKit~g" ${IOS_PROJECT_DIR}/android/app/CMakeLists.txt
+sed -i '' "s~../../../~../UIKit/~g" ${IOS_PROJECT_DIR}/android/settings.gradle
+sed -i '' "s~../../~./UIKit/~g" ${IOS_PROJECT_DIR}/CMakeLists.txt
+sed -i '' "s~../../../../~../../UIKit/~g" ${IOS_PROJECT_DIR}/android/app/CMakeLists.txt
 
 PACKAGE_WITH_UNDERSCORES=${PACKAGE/./_} # e.g. com_example_DemoApp
 sed -i '' "s~com_example~${PACKAGE_WITH_UNDERSCORES}~g" ${TARGET_SOURCES_DIRECTORY}/androidMain.swift

--- a/create-android-project
+++ b/create-android-project
@@ -28,8 +28,8 @@ echo
 # We assume the iOS dir equals the project name
 TARGET_SOURCES_DIRECTORY=${IOS_PROJECT_DIR}/${APP_NAME}
 
-echo "Creating ${IOS_PROJECT_DIR}/Package.swift for Swift Package Manager with Product '${APP_NAME}'"
-cp "${TEMPLATE_PATH}/Package.swift" .
+echo "Creating ${IOS_PROJECT_DIR}/CMakeLists.txt"
+cp "${TEMPLATE_PATH}/CMakeLists.txt" .
 
 
 echo "Creating ${TARGET_SOURCES_DIRECTORY}/androidMain.swift with UIApplicationDelegate class 'AppDelegate'"
@@ -45,10 +45,10 @@ mkdir -p "${IOS_PROJECT_DIR}/android/app/src/main/java/${PACKAGE_WITH_FORWARDSLA
 PATH_TO_MAIN_ACTIVITY="${TEMPLATE_PATH}/android/app/src/main/java/com/example/MainActivity.kt"
 cp $PATH_TO_MAIN_ACTIVITY "${IOS_PROJECT_DIR}/android/app/src/main/java/${PACKAGE_WITH_FORWARDSLASHES}"
 
-echo "Creating Android Studio project at '${IOS_PROJECT_DIR}/android'"
+echo "Creating Android project at '${IOS_PROJECT_DIR}/android'"
 
 FILES_TO_CHANGE=(
-    "Package.swift"
+    "CMakeLists.txt"
     "android/app/build.gradle"
     "android/app/src/main/AndroidManifest.xml"
     "android/app/CMakeLists.txt"
@@ -61,7 +61,9 @@ do
     sed -i '' "s~com.example~${PACKAGE}~g" $file
 done
 
+# adjust path to UIKit
 sed -i '' "s~../../../~../UIKit~g" ${IOS_PROJECT_DIR}/android/settings.gradle
+sed -i '' "s~../../~./UIKit~g" ${IOS_PROJECT_DIR}/CMakeLists.txt
 sed -i '' "s~../../../../~../../UIKit~g" ${IOS_PROJECT_DIR}/android/app/CMakeLists.txt
 
 PACKAGE_WITH_UNDERSCORES=${PACKAGE/./_} # e.g. com_example_DemoApp

--- a/docs/PREPARE_IOS_PROJECT.md
+++ b/docs/PREPARE_IOS_PROJECT.md
@@ -1,7 +1,7 @@
 ## Prepare your iOS Project
 
 1. Delete `Main.storyboard` and remove its reference from `Info.plist`
-2. Remove the entire block `Application Scene Manifest` from `Info.plist` and delete `SceneDelegate.swift` because UIScene is not supported yet.
+2. Remove the entire block `Application Scene Manifest` from `Info.plist` and delete the file `SceneDelegate.swift`.
 3. Modify `AppDelegate.swift`:
 
 -   Remove the `@UIApplicationMain` attribute and make the `AppDelegate` class `final`

--- a/docs/PREPARE_IOS_PROJECT.md
+++ b/docs/PREPARE_IOS_PROJECT.md
@@ -1,16 +1,20 @@
-
 ## Prepare your iOS Project
 
 1. Delete `Main.storyboard` and remove its reference from `Info.plist`
+2. Remove the entire block `Application Scene Manifest` from `Info.plist` and delete `SceneDelegate.swift` because UIScene is not supported yet.
+3. Modify `AppDelegate.swift`:
 
-2. Modify `AppDelegate.swift`:
-- Remove the `@UIApplicationMain` attribute and make the `AppDelegate` class `final`
-- Initialize `UIWindow` and your initial `ViewController` in the `application` function
+-   Remove the `@UIApplicationMain` attribute and make the `AppDelegate` class `final`
+-   Initialize `UIWindow` and your initial `ViewController` in the `application` function
+-   Remove application delegates related to `UIScene` and `UISceneSession`
+
 ```swift
 // AppDelegate.swift
 
 // @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
@@ -20,18 +24,16 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 
         return true
     }
-    ...
 }
 ```
 
 3. Create a `main.swift` file:
+
 ```swift
 // main.swift
 
 import UIKit
 import Foundation
 
-var argv = [UnsafeMutablePointer<Int8>]()
-_ = UIApplicationMain(0, &argv, nil, NSStringFromClass(AppDelegate.self))
+_ = UIApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, NSStringFromClass(AppDelegate.self))
 ```
-


### PR DESCRIPTION
**Type of change:** fix tooling

## Motivation (current vs expected behavior)
- fix `create-android-project` to work with new CMake based toolchain
- enhance readmes to cover new xcodes new iOS 13 project templates


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
