### PR TITLE
Fix Hashable conformance of UIColor (and crashes when storing them in Collections)

### DIFF
--- a/Sources/AnimatableProperty.swift
+++ b/Sources/AnimatableProperty.swift
@@ -10,15 +10,15 @@ public protocol AnimatableProperty {}
 
 extension CGColor: AnimatableProperty {
     func interpolation(to endResult: CGColor, progress: CGFloat) -> UIColor {
-        let startR = Int(red)
-        let startG = Int(green)
-        let startB = Int(blue)
-        let startA = Int(alpha)
+        let startR = Int(redValue)
+        let startG = Int(greenValue)
+        let startB = Int(blueValue)
+        let startA = Int(alphaValue)
 
-        let endR = Int(endResult.red)
-        let endG = Int(endResult.green)
-        let endB = Int(endResult.blue)
-        let endA = Int(endResult.alpha)
+        let endR = Int(endResult.redValue)
+        let endG = Int(endResult.greenValue)
+        let endB = Int(endResult.blueValue)
+        let endA = Int(endResult.alphaValue)
 
         let currentProgress = Int(progress.normalisedToUInt8())
         let maxProgress = Int(UInt8.max)

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -73,7 +73,7 @@ extension CALayer {
         }
 
         if let backgroundColor = backgroundColor {
-            let backgroundColorOpacity = opacity * backgroundColor.alpha.toNormalisedFloat()
+            let backgroundColorOpacity = opacity * backgroundColor.alphaValue.toNormalisedFloat()
             renderer.fill(
                 renderedBoundsRelativeToAnchorPoint,
                 with: backgroundColor.withAlphaComponent(CGFloat(backgroundColorOpacity)),

--- a/Sources/UIColor.swift
+++ b/Sources/UIColor.swift
@@ -14,10 +14,10 @@ import SDL
 import class Foundation.NSObject
 //
 public class UIColor: NSObject/*, Hashable*/ {
-    let red: UInt8
-    let green: UInt8
-    let blue: UInt8
-    let alpha: UInt8
+    let redValue: UInt8
+    let greenValue: UInt8
+    let blueValue: UInt8
+    let alphaValue: UInt8
 
     convenience init(hex: Int, alpha: CGFloat = 1) {
         let red = (hex & 0xFF0000) >> 16
@@ -27,10 +27,10 @@ public class UIColor: NSObject/*, Hashable*/ {
     }
 
     public init(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
-        self.red = red.normalisedToUInt8()
-        self.green = green.normalisedToUInt8()
-        self.blue = blue.normalisedToUInt8()
-        self.alpha = alpha.normalisedToUInt8()
+        self.redValue = red.normalisedToUInt8()
+        self.greenValue = green.normalisedToUInt8()
+        self.blueValue = blue.normalisedToUInt8()
+        self.alphaValue = alpha.normalisedToUInt8()
     }
 
     // from wikipedia: https://en.wikipedia.org/wiki/HSL_and_HSV
@@ -68,19 +68,19 @@ public class UIColor: NSObject/*, Hashable*/ {
     // FIXME: mocked!
     public init(patternImage: UIImage?) {
         // TODO: define a color object for specified Quartz color reference https://developer.apple.com/documentation/uikit/uicolor/1621933-init
-        self.red = 255
-        self.green = 255
-        self.blue = 255
-        self.alpha = 255
+        self.redValue = 255
+        self.greenValue = 255
+        self.blueValue = 255
+        self.alphaValue = 255
     }
     
     public static func == (lhs: UIColor, rhs: UIColor) -> Bool {
-        return (lhs.red == rhs.red) && (lhs.green == rhs.green) && (lhs.blue == rhs.blue) && (lhs.alpha == rhs.alpha)
+        return (lhs.redValue == rhs.redValue) && (lhs.greenValue == rhs.greenValue) && (lhs.blueValue == rhs.blueValue) && (lhs.alphaValue == rhs.alphaValue)
     }
 
     // Initialise from a color struct from e.g. renderer.getDrawColor()
     init(_ tuple: (r: UInt8, g: UInt8, b: UInt8, a: UInt8)) {
-        red = tuple.r; green = tuple.g; blue = tuple.b; alpha = tuple.a
+        redValue = tuple.r; greenValue = tuple.g; blueValue = tuple.b; alphaValue = tuple.a
     }
 }
 
@@ -109,7 +109,7 @@ extension UIColor {
     }
 
     public func withAlphaComponent(_ alpha: CGFloat) -> UIColor {
-        return UIColor((self.red, self.green, self.blue, alpha.normalisedToUInt8()))
+        return UIColor((self.redValue, self.greenValue, self.blueValue, alpha.normalisedToUInt8()))
     }
 }
 
@@ -139,6 +139,6 @@ extension Float {
 
 extension UIColor {
     var sdlColor: SDLColor {
-        return SDLColor(r: red, g: green, b: blue, a: alpha)
+        return SDLColor(r: redValue, g: greenValue, b: blueValue, a: alphaValue)
     }
 }

--- a/Sources/UINavigationBarAndroid.swift
+++ b/Sources/UINavigationBarAndroid.swift
@@ -78,7 +78,7 @@ private class UINavigationButtonAndroid: Button {
 extension UIColor {
     func isDarkEnoughToWarrantWhiteText() -> Bool {
         let thresholdLevel = Int(UInt8.max) / 2
-        let totalColourIntensity = Int(red) + Int(green) + Int(blue)
+        let totalColourIntensity = Int(redValue) + Int(greenValue) + Int(blueValue)
         return (totalColourIntensity / 3) < thresholdLevel
     }
 }


### PR DESCRIPTION
Fixes crashes when storing UIColor or objects containing UIColors in Collections.

**Type of change:** Bug fix

## Motivation (current vs expected behavior)

There are two changes in this PR:

1. We renamed `UIColor.self.red` etc. to `.redValue` to avoid clashing with the static properties `UIColor.red` etc.
2. We override the `hash` property to stop the Swift runtime from using `ObjectIdentifier(self).hashValue`, which is the default for NSObject.

This should fix a lot of crashes we were seeing on Android.

## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [x] Tests for the changes have been added (for bug fixes / features)
