### PR TITLE
explicitly set base sdk and supported platforms for UIKit mac target

### DIFF
--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -1379,6 +1379,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1433,6 +1434,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1455,7 +1457,9 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flowkey.UIKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/swift-jni/Sources/CJNI/include $(PROJECT_DIR)/SDL/SDL2/include $(PROJECT_DIR)/SDL/sdl-gpu/include $(PROJECT_DIR)/SDL/SDL_ttf/include";
 				SWIFT_VERSION = 4.2;
 			};
@@ -1477,7 +1481,9 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flowkey.UIKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/swift-jni/Sources/CJNI/include $(PROJECT_DIR)/SDL/SDL2/include $(PROJECT_DIR)/SDL/sdl-gpu/include $(PROJECT_DIR)/SDL/SDL_ttf/include";
 				SWIFT_VERSION = 4.2;
 			};

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -1544,6 +1544,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.christianhaug.iOSTestTarget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1564,6 +1565,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.christianhaug.iOSTestTarget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
**Type of change:** dx

## Motivation (current vs expected behavior)
This pr explicitly sets base sdk and supported platforms for the mac target to mac osx.
Otherwise apples new build system gets confused when building a project which has a reference to UIKit-cross-platform. My guess is that this is a bug in the build system, because the values should already default to macos (thats at least what xcode is showing) but for some reason they fallback to ios which obviously makes no sense.


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
