### PR TITLE
Fix GestureRecognizers not filtering `touchesEnded` events properly

### DIFF
--- a/Sources/UIGestureRecognizer.swift
+++ b/Sources/UIGestureRecognizer.swift
@@ -39,6 +39,7 @@ open class UIGestureRecognizer {
                 state = .possible
             case .changed:
                 cancelOtherGestureRecognizersThatShouldNotRecognizeSimultaneously()
+                cancelTouchesInViewIfApplicable()
             default: break
             }
         }
@@ -87,6 +88,12 @@ private extension UIGestureRecognizer {
             }
 
             $0.touchesCancelled([touch], with: UIEvent())
+        }
+    }
+
+    private func cancelTouchesInViewIfApplicable() {
+        if self.cancelsTouchesInView {
+            trackedTouch?.hasBeenCancelledByAGestureRecognizer = true
         }
     }
 }

--- a/Sources/UITouch.swift
+++ b/Sources/UITouch.swift
@@ -53,6 +53,8 @@ public class UITouch {
             action(recognizer)
         }
     }
+
+    var hasBeenCancelledByAGestureRecognizer = false
 }
 
 extension UITouch: Hashable {

--- a/Sources/UITouch.swift
+++ b/Sources/UITouch.swift
@@ -54,7 +54,7 @@ public class UITouch {
         }
     }
 
-    var hasBeenCancelledByAGestureRecognizer = false
+    internal var hasBeenCancelledByAGestureRecognizer = false
 }
 
 extension UITouch: Hashable {

--- a/Sources/UIWindow.swift
+++ b/Sources/UIWindow.swift
@@ -57,12 +57,6 @@ public class UIWindow: UIView {
     }
 }
 
-private extension UITouch {
-    var hasBeenCancelledByAGestureRecognizer: Bool {
-        return gestureRecognizers.contains(where: { ($0.state == .changed) && $0.cancelsTouchesInView })
-    }
-}
-
 private extension UIView {
     func getRecognizerHierachy() -> [UIGestureRecognizer] {
         var recognizerHierachy: [UIGestureRecognizer] = []

--- a/UIKitTests/Gestures/TouchHandlingTests.swift
+++ b/UIKitTests/Gestures/TouchHandlingTests.swift
@@ -48,6 +48,7 @@ class TouchHandlingTests: XCTestCase {
         handleTouchUp(CGPoint(x: 15, y: 10))
 
         XCTAssertFalse(view.touchesMovedWasCalled)
+        XCTAssertFalse(view.touchesEndedWasCalled)
     }
 
     func testDoesNotCancelTouchesInView() {
@@ -58,6 +59,7 @@ class TouchHandlingTests: XCTestCase {
         handleTouchUp(CGPoint(x: 15, y: 10))
 
         XCTAssertTrue(view.touchesMovedWasCalled)
+        XCTAssertTrue(view.touchesEndedWasCalled)
     }
 
     func testShouldNotRecognizeSimultaneously() {
@@ -80,8 +82,14 @@ class TouchHandlingTests: XCTestCase {
 private extension TouchHandlingTests {
     class ResponderView: UIView {
         var touchesMovedWasCalled = false
+        var touchesEndedWasCalled = false
+
         override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
             touchesMovedWasCalled = true
+        }
+
+        override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+            touchesEndedWasCalled = true
         }
     }
 


### PR DESCRIPTION
**Type of change:** Bug fix

## Motivation (current vs expected behavior)

When a user drags around a view with an active `UIGestureRecognizer`, that recognizer should cancel the touches sent to this view by default (and let them pass if `cancelsTouchesInView` was explicitly set to `false`). 

This PR improves the handling of UITouch's internal `hasBeenCancelledByAGestureRecognizer` variable to ensure that happens.




## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [x] Tests for the changes have been added (for bug fixes / features)
