### PR TITLE
Fix scrollview deceleration reporting

### DIFF
--- a/Sources/UIPanGestureRecognizer.swift
+++ b/Sources/UIPanGestureRecognizer.swift
@@ -11,8 +11,9 @@ import Foundation
 open class UIPanGestureRecognizer: UIGestureRecognizer {
     private var initialTouchPoint: CGPoint?
 
-    private var previousTouchesMovedTimestamp: TimeInterval?
-    private var touchesMovedTimestamp: TimeInterval?
+    // TODO: make an extension in tests instead of changing this to internal from private
+    internal var previousTouchesMovedTimestamp: TimeInterval?
+    internal var touchesMovedTimestamp: TimeInterval?
 
     private let minimumTranslationThreshold: CGFloat = 5
 

--- a/Sources/UIPanGestureRecognizer.swift
+++ b/Sources/UIPanGestureRecognizer.swift
@@ -11,7 +11,6 @@ import Foundation
 open class UIPanGestureRecognizer: UIGestureRecognizer {
     private var initialTouchPoint: CGPoint?
 
-    // TODO: make an extension in tests instead of changing this to internal from private
     internal var previousTouchesMovedTimestamp: TimeInterval?
     internal var touchesMovedTimestamp: TimeInterval?
 

--- a/Sources/UIScrollView+velocity.swift
+++ b/Sources/UIScrollView+velocity.swift
@@ -45,15 +45,6 @@ extension UIScrollView {
         })
     }
 
-    func cancelDeceleratingIfNeccessary() {
-        if !isDecelerating { return }
-
-        // Get the presentation value from the current animation
-        setContentOffset(visibleContentOffset, animated: false)
-        cancelDecelerationAnimations()
-        isDecelerating = false
-    }
-
     func cancelDecelerationAnimations() {
         layer.removeAnimation(forKey: "bounds")
         horizontalScrollIndicator.layer.removeAnimation(forKey: "position")

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -80,7 +80,7 @@ open class UIScrollView: UIView {
 
     open var isDecelerating = false {
         didSet {
-            // Hide when we stop decelerating, but only when that wasn't because of a pan
+            // Hide scroll indicators when we stop decelerating, but only when that wasn't because of a pan
             if !isDecelerating && panGestureRecognizer.state == .possible {
                 hideScrollIndicators()
             }

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -103,8 +103,12 @@ open class UIScrollView: UIView {
         case .began:
             showScrollIndicators()
             delegate?.scrollViewWillBeginDragging(self)
-            cancelDeceleratingIfNeccessary()
+            if isDecelerating {
+                setContentOffset(visibleContentOffset, animated: false)
+                cancelDecelerationAnimations()
+            }
         case .ended:
+            self.isDecelerating = false
             startDeceleratingIfNecessary()
             weightedAverageVelocity = .zero
 

--- a/UIKitTests/UIScrollViewTests.swift
+++ b/UIKitTests/UIScrollViewTests.swift
@@ -110,6 +110,28 @@ class UIScrollViewTests: XCTestCase {
         // XXX: set style, test bgr -> does this need to be tested?
     }
 
+    func testIsDecelerating() {
+        XCTAssertEqual(scrollView.isDecelerating, false)
+
+        let mockTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
+        scrollView.panGestureRecognizer.trackedTouch = mockTouch
+        scrollView.panGestureRecognizer.touchesBegan([mockTouch], with: UIEvent())
+        mockTouch.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
+        scrollView.panGestureRecognizer.touchesMoved([mockTouch], with: UIEvent())
+
+        // Necessary to mock velocity scroll
+        scrollView.contentOffset = CGPoint(x: -30, y: -40)
+        scrollView.panGestureRecognizer.previousTouchesMovedTimestamp = 3.141
+        scrollView.panGestureRecognizer.touchesMovedTimestamp = 3.140
+
+        XCTAssertEqual(scrollView.isDecelerating, false)
+        scrollView.panGestureRecognizer.touchesEnded([mockTouch], with: UIEvent())
+        XCTAssertEqual(scrollView.isDecelerating, true)
+
+        // XXX: optional and problematic: add another touch that "stops" the velocity scroll
+        // First investigate if it's necessary - maybe this test already covers the problem
+    }
+
     func testDelegateMethods() {
         class DelegationTestScrollView: UIScrollView, UIScrollViewDelegate {
 
@@ -158,11 +180,11 @@ class UIScrollViewTests: XCTestCase {
         wait(for: [beginDraggingExpectation, didScrollExpectation, didEndDraggingExpectation], timeout: 1.0)
     }
 
-    func mockTouch(toPoint: CGPoint, inScrollView scrollView: UIScrollView) {
+    func mockTouch(toPoint point: CGPoint, inScrollView scrollView: UIScrollView) {
         let mockTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
 
         scrollView.panGestureRecognizer.touchesBegan([mockTouch], with: UIEvent())
-        mockTouch.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
+        mockTouch.updateAbsoluteLocation(point)
         scrollView.panGestureRecognizer.touchesMoved([mockTouch], with: UIEvent())
         scrollView.panGestureRecognizer.touchesEnded([mockTouch], with: UIEvent())
     }

--- a/UIKitTests/UIScrollViewTests.swift
+++ b/UIKitTests/UIScrollViewTests.swift
@@ -111,38 +111,38 @@ class UIScrollViewTests: XCTestCase {
     }
 
     func testIsDecelerating() {
-        // XXX: We are duplicating code with the `mockTouch` function
-        // because we have to put XCTAssertions inbetween
+        // This tests an edge case in iOS behaviour (while also testing some basics along the way)
+        // If Touch 1 starts a velocity scroll, and a separate Touch 2 ends it,
+        // the scrollView should be marked as `isDecelerating` until Touch 2 is lifted (not until it begins)
 
         XCTAssertEqual(scrollView.isDecelerating, false)
 
-        let mockedTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
-        scrollView.panGestureRecognizer.trackedTouch = mockedTouch
-        scrollView.panGestureRecognizer.touchesBegan([mockedTouch], with: UIEvent())
-        mockedTouch.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
-        scrollView.panGestureRecognizer.touchesMoved([mockedTouch], with: UIEvent())
+        // Mock Touch 1, with a velocity scroll
+        let mockedTouch1 = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
+        scrollView.panGestureRecognizer.trackedTouch = mockedTouch1
+        scrollView.panGestureRecognizer.touchesBegan([mockedTouch1], with: UIEvent())
+        mockedTouch1.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
+        scrollView.panGestureRecognizer.touchesMoved([mockedTouch1], with: UIEvent())
 
-        // Mock a velocity scroll
-        scrollView.contentOffset = CGPoint(x: -30, y: -40)
-        scrollView.panGestureRecognizer.previousTouchesMovedTimestamp = 3.141
-        scrollView.panGestureRecognizer.touchesMovedTimestamp = 3.140
-
+        scrollView.contentOffset = CGPoint(x: -10, y: -10)
+        scrollView.panGestureRecognizer.previousTouchesMovedTimestamp = 0.002
+        scrollView.panGestureRecognizer.touchesMovedTimestamp = 0.001
         XCTAssertEqual(scrollView.isDecelerating, false)
 
-        scrollView.panGestureRecognizer.touchesEnded([mockedTouch], with: UIEvent())
+        scrollView.panGestureRecognizer.touchesEnded([mockedTouch1], with: UIEvent())
         XCTAssertEqual(scrollView.isDecelerating, true)
 
-
-        let mockTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
+        // Mock Touch 2
+        let mockedTouch2 = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
         let point = CGPoint(x: 0, y: 0)
-        scrollView.panGestureRecognizer.touchesBegan([mockTouch], with: UIEvent())
-
+        scrollView.panGestureRecognizer.touchesBegan([mockedTouch2], with: UIEvent())
         XCTAssertEqual(scrollView.isDecelerating, true)
 
-        mockTouch.updateAbsoluteLocation(point)
-        scrollView.panGestureRecognizer.touchesMoved([mockTouch], with: UIEvent())
-        scrollView.panGestureRecognizer.touchesEnded([mockTouch], with: UIEvent())
+        mockedTouch2.updateAbsoluteLocation(point)
+        scrollView.panGestureRecognizer.touchesMoved([mockedTouch2], with: UIEvent())
+        XCTAssertEqual(scrollView.isDecelerating, true)
 
+        scrollView.panGestureRecognizer.touchesEnded([mockedTouch2], with: UIEvent())
         XCTAssertEqual(scrollView.isDecelerating, false)
     }
 

--- a/UIKitTests/UIScrollViewTests.swift
+++ b/UIKitTests/UIScrollViewTests.swift
@@ -111,25 +111,39 @@ class UIScrollViewTests: XCTestCase {
     }
 
     func testIsDecelerating() {
+        // XXX: We are duplicating code with the `mockTouch` function
+        // because we have to put XCTAssertions inbetween
+
         XCTAssertEqual(scrollView.isDecelerating, false)
 
-        let mockTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
-        scrollView.panGestureRecognizer.trackedTouch = mockTouch
-        scrollView.panGestureRecognizer.touchesBegan([mockTouch], with: UIEvent())
-        mockTouch.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
-        scrollView.panGestureRecognizer.touchesMoved([mockTouch], with: UIEvent())
+        let mockedTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
+        scrollView.panGestureRecognizer.trackedTouch = mockedTouch
+        scrollView.panGestureRecognizer.touchesBegan([mockedTouch], with: UIEvent())
+        mockedTouch.updateAbsoluteLocation(CGPoint(x: 100, y: 100))
+        scrollView.panGestureRecognizer.touchesMoved([mockedTouch], with: UIEvent())
 
-        // Necessary to mock velocity scroll
+        // Mock a velocity scroll
         scrollView.contentOffset = CGPoint(x: -30, y: -40)
         scrollView.panGestureRecognizer.previousTouchesMovedTimestamp = 3.141
         scrollView.panGestureRecognizer.touchesMovedTimestamp = 3.140
 
         XCTAssertEqual(scrollView.isDecelerating, false)
-        scrollView.panGestureRecognizer.touchesEnded([mockTouch], with: UIEvent())
+
+        scrollView.panGestureRecognizer.touchesEnded([mockedTouch], with: UIEvent())
         XCTAssertEqual(scrollView.isDecelerating, true)
 
-        // XXX: optional and problematic: add another touch that "stops" the velocity scroll
-        // First investigate if it's necessary - maybe this test already covers the problem
+
+        let mockTouch = UITouch(touchId: 0, at: CGPoint(x: 0, y: 0), timestamp: 0)
+        let point = CGPoint(x: 0, y: 0)
+        scrollView.panGestureRecognizer.touchesBegan([mockTouch], with: UIEvent())
+
+        XCTAssertEqual(scrollView.isDecelerating, true)
+
+        mockTouch.updateAbsoluteLocation(point)
+        scrollView.panGestureRecognizer.touchesMoved([mockTouch], with: UIEvent())
+        scrollView.panGestureRecognizer.touchesEnded([mockTouch], with: UIEvent())
+
+        XCTAssertEqual(scrollView.isDecelerating, false)
     }
 
     func testDelegateMethods() {


### PR DESCRIPTION
**Type of change:** Bug fix

## Motivation (current vs expected behavior)
When comparing behaviour with iOS, I realized that the `isDecelerating` value for `scrollView` is not being reported the same. 

The scenario was: one "fast" pan that starts a velocity scroll, then another touch that stops it, maybe pans around a bit, and releases. 

As soon as the first pan is released and the velocity scroll starts, `isDecelerating` is `true`. 
Then when the second touch starts, the visible deceleration stops and we are reporting `isDecelerating == false`. This seems reasonable, but it's not what iOS does. On iOS, the scrollView is still marked as decelerating, until the touch is released. 

This PR aligns behavior with iOS and adds a test that covers this case.

## Warning
I realized that the difference in behaviour could come from the LongPressRecognizer that's there in iOS (but not yet in UIKit-crossplatform). If that's the case, this is likely not the right fix - please keep that in mind and let me know.

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] The commit messages are clean and understandable
- [x] Tests for the changes have been added (for bug fixes / features)
