### PR TITLE
Fix for `insertSubview` being off by one

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -185,6 +185,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     open func insertSubview(_ view: UIView, at index: Int) {
         // XXX: This might not cover all cases yet. Managing these two hierarchies is complex...
+        insertSubviewWithoutTouchingLayer(view, at: index)
         let indexOfViewWeJustPushedForwardInArray = index + 1
         if index == 0 {
             layer.insertSublayer(view.layer, at: 0)
@@ -195,8 +196,6 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
             // We didn't replace any view. Just push the new layer to the end of the sublayers array.
             layer.addSublayer(view.layer)
         }
-
-        insertSubviewWithoutTouchingLayer(view, at: index)
     }
 
     private func safeGetSubview(index: Int) -> UIView? {

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -185,17 +185,16 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     open func insertSubview(_ view: UIView, at index: Int) {
         // XXX: This might not cover all cases yet. Managing these two hierarchies is complex...
-        insertSubviewWithoutTouchingLayer(view, at: index)
-        let indexOfViewWeJustPushedForwardInArray = index + 1
         if index == 0 {
             layer.insertSublayer(view.layer, at: 0)
-        } else if let currentSubview = safeGetSubview(index: indexOfViewWeJustPushedForwardInArray) {
+        } else if let currentSubview = safeGetSubview(index: index) {
             layer.insertSublayer(view.layer, below: currentSubview.layer)
         } else {
             // The given index was greater than that of any existing subview, meaning:
             // We didn't replace any view. Just push the new layer to the end of the sublayers array.
             layer.addSublayer(view.layer)
         }
+        insertSubviewWithoutTouchingLayer(view, at: index)
     }
 
     private func safeGetSubview(index: Int) -> UIView? {

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -194,7 +194,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
             // We didn't replace any view. Just push the new layer to the end of the sublayers array.
             layer.addSublayer(view.layer)
         }
-        
+
         insertSubviewWithoutTouchingLayer(view, at: index)
     }
 

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -194,6 +194,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
             // We didn't replace any view. Just push the new layer to the end of the sublayers array.
             layer.addSublayer(view.layer)
         }
+        
         insertSubviewWithoutTouchingLayer(view, at: index)
     }
 

--- a/UIKitTests/UIView/UIViewTests+subviews.swift
+++ b/UIKitTests/UIView/UIViewTests+subviews.swift
@@ -69,7 +69,6 @@ class UIViewSubviewTests: XCTestCase {
 
         view.addSubview(subview1)
         view.addSubview(subview2)
-
         view.insertSubview(subview3, at: 1)
 
         XCTAssertEqual(view.subviews, [subview1, subview3, subview2])

--- a/UIKitTests/UIView/UIViewTests+subviews.swift
+++ b/UIKitTests/UIView/UIViewTests+subviews.swift
@@ -61,6 +61,21 @@ class UIViewSubviewTests: XCTestCase {
         XCTAssertEqual(view.layer.sublayers!, [subview1.layer, subview2.layer])
     }
 
+    func testInsertSubviewAtIndex() {
+        let view = UIView()
+        let subview1 = UIView()
+        let subview2 = UIView()
+        let subview3 = UIView()
+
+        view.addSubview(subview1)
+        view.addSubview(subview2)
+
+        view.insertSubview(subview3, at: 1)
+
+        XCTAssertEqual(view.subviews, [subview1, subview3, subview2])
+        XCTAssertEqual(view.layer.sublayers!, [subview1.layer, subview3.layer, subview2.layer])
+    }
+
     func testInsertSubviewAboveNonExistentSibling() {
         let view = UIView()
         let subview1 = UIView()


### PR DESCRIPTION
Fixes #308 
**Type of change:** Bug fix

## Motivation

We had a bug in `insertSubview` where we would use expected new positions in subview hierarchy before the hierarchy is updated. This fix uses the old hierarchy. 

Visually in DemoApp it looks correct (where it previously was wrong). I also added a test that would fail on master, but passes here and on iOS.

## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [x] Tests for the changes have been added (for bug fixes / features)
