### PR TITLE
Fix crash on native touch

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -65,6 +65,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
     external override fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
     override var mWidth: Float = 1.0f // Keep track of the surface size to normalize touch events
     override var mHeight: Float = 1.0f // Start with non-zero values to avoid potential division by zero
+    override var canSavelyCallOnNativeTouch = false
 
     // APKExtensionStreamOpener conformance
     external override fun nativeGetHint(name: String): String?
@@ -108,6 +109,9 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
         if (hasFocus) {
             handleResume()
+            this.canSavelyCallOnNativeTouch = true
+        } else {
+            this.canSavelyCallOnNativeTouch = false
         }
     }
 

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -45,7 +45,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
     private var mSurface: SurfaceView
     private var mIsSurfaceReady = false
-    private var mHasFocus = false
+    override var mHasFocus = false
 
     private external fun nativeProcessEventsAndRender()
     private external fun nativeInit(): Int
@@ -65,7 +65,6 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
     external override fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
     override var mWidth: Float = 1.0f // Keep track of the surface size to normalize touch events
     override var mHeight: Float = 1.0f // Start with non-zero values to avoid potential division by zero
-    override var canSavelyCallOnNativeTouch = false
 
     // APKExtensionStreamOpener conformance
     external override fun nativeGetHint(name: String): String?
@@ -109,9 +108,6 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
         if (hasFocus) {
             handleResume()
-            this.canSavelyCallOnNativeTouch = true
-        } else {
-            this.canSavelyCallOnNativeTouch = false
         }
     }
 

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -56,11 +56,18 @@ interface SDLOnTouchListener: View.OnTouchListener {
         return true
     }
 
-    fun callOnNativeTouchIfHasFocus(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long) {
+    fun callOnNativeTouchIfHasFocus(
+            touchDevId: Int,
+            pointerFingerId: Int,
+            action: Int,
+            x: Float,
+            y: Float,
+            p: Float,
+            t: Long
+    ) {
         if (this.mHasFocus) {
             this.onNativeTouchUIKit(touchDevId, pointerFingerId, action, x, y, p, t)
         }
-
     }
 }
 

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -65,6 +65,8 @@ interface SDLOnTouchListener: View.OnTouchListener {
             p: Float,
             t: Long
     ) {
+        // check if we have focus because of a crash when re-entering the player 
+        // from a background state while touching (JNIEnv dead)
         if (this.mHasFocus) {
             this.onNativeTouchUIKit(touchDevId, pointerFingerId, action, x, y, p, t)
         }

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -11,6 +11,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
 
     var mWidth: Float
     var mHeight: Float
+    var canSavelyCallOnNativeTouch: Boolean
 
     fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
     fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
@@ -32,7 +33,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
             MotionEvent.ACTION_MOVE -> {
                 for (i in 0 until event.pointerCount) {
                     val (fingerId, x, y, pressure) = event.touchValues(i)
-                    this.onNativeTouchUIKit(touchDevId, fingerId, action, x, y, pressure, timestamp)
+                    this.callOnNativeTouchIfSave(touchDevId, fingerId, action, x, y, pressure, timestamp)
                 }
             }
 
@@ -41,18 +42,25 @@ interface SDLOnTouchListener: View.OnTouchListener {
             MotionEvent.ACTION_POINTER_UP,
             MotionEvent.ACTION_POINTER_DOWN -> {
                 val (fingerId, x, y, pressure) = event.touchValues(event.actionIndex)
-                this.onNativeTouchUIKit(touchDevId, fingerId, action, x, y, pressure, timestamp)
+                this.callOnNativeTouchIfSave(touchDevId, fingerId, action, x, y, pressure, timestamp)
             }
 
             MotionEvent.ACTION_CANCEL -> {
                 for (i in 0 until event.pointerCount) {
                     val (fingerId, x, y, pressure) = event.touchValues(i)
-                    this.onNativeTouchUIKit(touchDevId, fingerId, MotionEvent.ACTION_UP, x, y, pressure, timestamp)
+                    this.callOnNativeTouchIfSave(touchDevId, fingerId, MotionEvent.ACTION_UP, x, y, pressure, timestamp)
                 }
             }
         }
 
         return true
+    }
+
+    fun callOnNativeTouchIfSave(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long) {
+        if (this.canSavelyCallOnNativeTouch) {
+            this.onNativeTouchUIKit(touchDevId, pointerFingerId, action, x, y, p, t)
+        }
+
     }
 }
 

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -11,7 +11,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
 
     var mWidth: Float
     var mHeight: Float
-    var canSavelyCallOnNativeTouch: Boolean
+    var mHasFocus: Boolean
 
     fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
     fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
@@ -33,7 +33,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
             MotionEvent.ACTION_MOVE -> {
                 for (i in 0 until event.pointerCount) {
                     val (fingerId, x, y, pressure) = event.touchValues(i)
-                    this.callOnNativeTouchIfSave(touchDevId, fingerId, action, x, y, pressure, timestamp)
+                    this.callOnNativeTouchIfHasFocus(touchDevId, fingerId, action, x, y, pressure, timestamp)
                 }
             }
 
@@ -42,13 +42,13 @@ interface SDLOnTouchListener: View.OnTouchListener {
             MotionEvent.ACTION_POINTER_UP,
             MotionEvent.ACTION_POINTER_DOWN -> {
                 val (fingerId, x, y, pressure) = event.touchValues(event.actionIndex)
-                this.callOnNativeTouchIfSave(touchDevId, fingerId, action, x, y, pressure, timestamp)
+                this.callOnNativeTouchIfHasFocus(touchDevId, fingerId, action, x, y, pressure, timestamp)
             }
 
             MotionEvent.ACTION_CANCEL -> {
                 for (i in 0 until event.pointerCount) {
                     val (fingerId, x, y, pressure) = event.touchValues(i)
-                    this.callOnNativeTouchIfSave(touchDevId, fingerId, MotionEvent.ACTION_UP, x, y, pressure, timestamp)
+                    this.callOnNativeTouchIfHasFocus(touchDevId, fingerId, MotionEvent.ACTION_UP, x, y, pressure, timestamp)
                 }
             }
         }
@@ -56,8 +56,8 @@ interface SDLOnTouchListener: View.OnTouchListener {
         return true
     }
 
-    fun callOnNativeTouchIfSave(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long) {
-        if (this.canSavelyCallOnNativeTouch) {
+    fun callOnNativeTouchIfHasFocus(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long) {
+        if (this.mHasFocus) {
             this.onNativeTouchUIKit(touchDevId, pointerFingerId, action, x, y, p, t)
         }
 


### PR DESCRIPTION
**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->
Bug Fix

## Motivation (current vs expected behavior)
Fixes a crash that happens when re-entering from a background state while still touching the screen. The app then crashes because `Java_org_libsdl_app_SDLActivity_onNativeTouchUIKit` is called, but the JNIEnv or the object argument is not yet available again. Checking for `mHasFocus` before calling the `onNativeTouch` fixes the issue.

## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
