### PR TITLE
fix getBoundsCheckedContentOffset when bounds is bigger than contentSize

### DIFF
--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -50,9 +50,11 @@ open class UIScrollView: UIView {
 
     /// does some min/max checks to prevent newOffset being out of bounds
     func getBoundsCheckedContentOffset(_ newContentOffset: CGPoint) -> CGPoint {
+        let contentHeight = max(contentSize.height, bounds.height)
+        let contentWidth = max(contentSize.width, bounds.width)
         return CGPoint(
-            x: min(max(newContentOffset.x, -contentInset.left), (contentSize.width + contentInset.right) - bounds.width),
-            y: min(max(newContentOffset.y, -contentInset.top), (contentSize.height + contentInset.bottom) - bounds.height)
+            x: min(max(newContentOffset.x, -contentInset.left), (contentWidth + contentInset.right) - bounds.width),
+            y: min(max(newContentOffset.y, -contentInset.top), (contentHeight + contentInset.bottom) - bounds.height)
         )
     }
 


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
Our UIScrollview implementation currently jumps to the end of the list when `onPan` gets called and the contentSize dimensions are smaller than the bounds dimensions of the scrollview.


![screeen](https://user-images.githubusercontent.com/5617793/107209788-91e3be80-6a03-11eb-9406-673f0ef36ad5.png)

https://user-images.githubusercontent.com/5617793/107209784-914b2800-6a03-11eb-9d28-c69190512963.mp4




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
