### PR TITLE
fix outline rendering when borderWidth > 1

### DIFF
--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -100,15 +100,25 @@ extension UIScreen {
             width: rect.size.width - offset,
             height: rect.size.height - offset
         ).gpuRect(scale: scale)
-        
+
         GPU_SetLineThickness(Float(lineThickness))
         GPU_Rectangle(rawPointer, scaledGpuRect, color: lineColor.sdlColor)
     }
 
     func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat, cornerRadius: CGFloat) {
         if cornerRadius > 1 {
+            // we want to render the outline 'inside' the rect rather
+            // than exceeding the bounds when lineThickness is bigger than 1
+            let offset = lineThickness / 2
+            let scaledGpuRect = CGRect(
+                x: rect.origin.x + offset,
+                y: rect.origin.y + offset,
+                width: rect.size.width - offset,
+                height: rect.size.height - offset
+            ).gpuRect(scale: scale)
+
             GPU_SetLineThickness(Float(lineThickness))
-            GPU_RectangleRound(rawPointer, rect.gpuRect(scale: scale), cornerRadius: Float(cornerRadius), color: lineColor.sdlColor)
+            GPU_RectangleRound(rawPointer, scaledGpuRect, cornerRadius: Float(cornerRadius), color: lineColor.sdlColor)
         } else {
             outline(rect, lineColor: lineColor, lineThickness: lineThickness)
         }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -91,8 +91,18 @@ extension UIScreen {
     }
 
     func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat) {
+        // we want to render the outline 'inside' the rect rather
+        // than exceeding the bounds when lineThickness is bigger than 1
+        let offset = lineThickness / 2
+        let scaledGpuRect = CGRect(
+            x: rect.origin.x + offset,
+            y: rect.origin.y + offset,
+            width: rect.size.width - offset,
+            height: rect.size.height - offset
+        ).gpuRect(scale: scale)
+        
         GPU_SetLineThickness(Float(lineThickness))
-        GPU_Rectangle(rawPointer, rect.gpuRect(scale: scale), color: lineColor.sdlColor)
+        GPU_Rectangle(rawPointer, scaledGpuRect, color: lineColor.sdlColor)
     }
 
     func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat, cornerRadius: CGFloat) {


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
We have to manually make sure the drawn rect does not exceed the bounds of the base rect when setting a borderWidth bigger than 1

Look close to the top left edge of the first exercise part border (orange outline) to see the issue:

### broken:
![border-bad_round](https://user-images.githubusercontent.com/5617793/107505976-b96e8e80-6b9d-11eb-8b70-d281aabd2a72.png)

![border-fucked](https://user-images.githubusercontent.com/5617793/107505722-698fc780-6b9d-11eb-8def-c9eed483a481.png)

### fixed:
![border-nice_round](https://user-images.githubusercontent.com/5617793/107505981-bb385200-6b9d-11eb-8619-08d99fc60433.png)


![nice_border](https://user-images.githubusercontent.com/5617793/107505729-6bf22180-6b9d-11eb-9b6d-86bc1f799b96.png)







## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
