### PR TITLE
only cancel bounds animation when setting contentOffset without animations

### DIFF
--- a/Sources/CATransaction.swift
+++ b/Sources/CATransaction.swift
@@ -11,7 +11,7 @@ public struct CATransaction {
     private var disableActions_ = false
     private var animationDuration_: CGFloat = CALayer.defaultAnimationDuration
 
-    private static var transactionStack = [CATransaction]()
+    internal static var transactionStack = [CATransaction]()
 
     public static func begin() {
         transactionStack.append(CATransaction())

--- a/Sources/CATransaction.swift
+++ b/Sources/CATransaction.swift
@@ -11,7 +11,7 @@ public struct CATransaction {
     private var disableActions_ = false
     private var animationDuration_: CGFloat = CALayer.defaultAnimationDuration
 
-    internal static var transactionStack = [CATransaction]()
+    internal private(set) static var transactionStack = [CATransaction]()
 
     public static func begin() {
         transactionStack.append(CATransaction())

--- a/Sources/UIScrollView+velocity.swift
+++ b/Sources/UIScrollView+velocity.swift
@@ -62,8 +62,10 @@ extension UIScrollView {
     }
 
     func cancelDecelerationAnimations() {
-        layer.removeAnimation(forKey: "bounds")
-        horizontalScrollIndicator.layer.removeAnimation(forKey: "position")
-        verticalScrollIndicator.layer.removeAnimation(forKey: "position")
+        if !layer.animations.isEmpty {
+            layer.removeAnimation(forKey: "bounds")
+            horizontalScrollIndicator.layer.removeAnimation(forKey: "position")
+            verticalScrollIndicator.layer.removeAnimation(forKey: "position")
+        }
     }
 }

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -23,7 +23,13 @@ open class UIScrollView: UIView {
         get { return bounds.origin }
         set {
             guard newValue != contentOffset else { return }
-            cancelDecelerationAnimations()
+
+            // Cancel deceleration animations only when contentOffset gets set without animations.
+            // Otherwise we might cancel any "bounds" animations which are not iniated from velocity scrolling.
+            if isDecelerating && CATransaction.transactionStack.isEmpty {
+                cancelDecelerationAnimations()
+            }
+
             bounds.origin = newValue
             layoutScrollIndicatorsIfNeeded()
         }


### PR DESCRIPTION
**Type of change:** bugfix (align with ios behaviour)

## Motivation (current vs expected behavior)
Due some recent changes in the coursesv2 player logic it can happen that we sometimes have two sheet animations animating back to the beginning of the song or to the beginning of the loop. It might be possible to clean this up, but from UIKit perspective this should work, because initiating another contentOffset animation should just override the existing one and then either create a new animation starting from `layer.bounds` or `presentation.bounds` depending on `beginFromCurrentState`. This works on iOS and it works in our UIKit when velocity scroll is disabled.

I noticed that we are removing any bounds animations when the contentOffset of a scrollView gets updated. We need this, otherwise there is a weird jump in the sheet when deceleration finishes and exoplayer updates the x position. But we also set the contentOffset when animating back in a loop or at the end of the sheet, in this case it does not make much sense to remove the animations.

I think the fix here is to remove the animations only when setting the contentOffset without animation (when set from exoplayer in our case). 

https://user-images.githubusercontent.com/5617793/107763467-f74eec80-6d2e-11eb-808d-0dba7f2cc61f.mp4







## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
