### PR TITLE
cleanup previous fix for velocity scroll animations

### DIFF
--- a/Sources/CATransaction.swift
+++ b/Sources/CATransaction.swift
@@ -11,7 +11,7 @@ public struct CATransaction {
     private var disableActions_ = false
     private var animationDuration_: CGFloat = CALayer.defaultAnimationDuration
 
-    internal private(set) static var transactionStack = [CATransaction]()
+    private static var transactionStack = [CATransaction]()
 
     public static func begin() {
         transactionStack.append(CATransaction())

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -26,7 +26,7 @@ open class UIScrollView: UIView {
 
             // Cancel deceleration animations only when contentOffset gets set without animations.
             // Otherwise we might cancel any "bounds" animations which are not iniated from velocity scrolling.
-            if isDecelerating && CATransaction.transactionStack.isEmpty {
+            if isDecelerating && UIView.currentAnimationPrototype == nil {
                 cancelDecelerationAnimations()
             }
 


### PR DESCRIPTION
**Type of change:** cleanup fix

## Motivation (current vs expected behavior)
This change is based on the previous feedback of @ephemer  in https://github.com/flowkey/UIKit-cross-platform/pull/319.
Instead of exposing the static transactionStack we can also just check if there is an animation prototype defined in `UIView.currentAnimationPrototype`. If this value is defined, we are currently in a stack trace of an animation closure.

The fix for the velocity scroll is to cancel all animations only when setting the contentOffset not from within an animation closure.





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
