### PR TITLE
Explicitly unwrap UIScreen.main before accesing its scale property

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -140,7 +140,10 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     public init(frame: CGRect) {
         self.layer = type(of: self).layerClass.init()
-        self.layer.contentsScale = UIScreen.main.scale
+        if let uiScreenMain = UIScreen.main {
+            self.layer.contentsScale = uiScreenMain.scale
+        }
+        
         super.init()
 
         self.layer.delegate = self


### PR DESCRIPTION
**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
Since `UIScreen.main` is an implicitly unwrapped optional, it would be safer to check it for nil before using its `scale` property.




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
