### PR TITLE
Overhaul SDLActivity.surfaceChanged

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -285,9 +285,6 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
             return
         }
 
-        var adjustedWidth = width
-        var adjustedHeight = height
-
         if (context is Activity) {
             val activity = context as Activity
             when (activity.requestedOrientation) {
@@ -295,27 +292,31 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
                 ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE,
                 ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE,
                 ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE -> {
-                    adjustedWidth = max(width, height)
-                    adjustedHeight = min(width, height)
+                    if (width < height) {
+                        Log.v(TAG, "skipping: orientation is landscape, but width < height")
+                        return
+                    }
                 }
                 ActivityInfo.SCREEN_ORIENTATION_PORTRAIT,
                 ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT,
                 ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT,
                 ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT -> {
-                    adjustedWidth = min(width, height)
-                    adjustedHeight = max(width, height)
+                    if (height < width) {
+                        Log.v(TAG, "skipping: orientation is portrait, but height < width")
+                        return
+                    }
                 }
             }
         }
 
-        if (mIsSurfaceReady && mWidth.toInt() == adjustedWidth && mHeight.toInt() == adjustedHeight) {
+        if (mIsSurfaceReady && mWidth.toInt() == width && mHeight.toInt() == height) {
             return
         }
 
         nativeDestroyScreen()
 
-        mWidth = adjustedWidth.toFloat()
-        mHeight = adjustedHeight.toFloat()
+        mWidth = width.toFloat()
+        mHeight = height.toFloat()
 
         this.onNativeResize(mWidth.toInt(), mHeight.toInt(), sdlFormat, display.refreshRate)
         Log.v(TAG, "Window size: " + mWidth + "x" + mHeight)


### PR DESCRIPTION
**Type of change:** Bug fix

## Motivation

Exit from `surfaceChanged()` early if the requested orientation is not yet the actual orientation.

This fixes layouting issues, since we are not destroying and then recreating our `UIScreen.main` anymore when the orientation changes. The problem with that was that `onNativeResize()` could not set the new screen resolution for the `Android_Window`, because it is `null` at that point ([see here](https://github.com/flowkey/SDL2-SwiftPackageManager/blob/ab962c68b37cae017de42043bf983e3564480718/external/SDL2/src/video/android/SDL_androidvideo.c#L221)).
Instead now we skip until the next `surfaceChanged()`, where the requested orientation matches the actual one and create the Screen only once with the correct dimensions.

Props to @michaelknoch who came up with the idea!

## Note I
~~I tested this fix on top of c8abdd213701a197a687bd7977cb19e0b057061c and not on the latest master.
When rebasing onto the latest master, I realized there is a crash when entering the flowkey player. Looks like it got introduced in 196ab113ab457a2c393689317b9fe6c067c75fd7. So that would need to get fixed, before we can use the latest UIKit master.~~
edit: [PR is open](https://github.com/flowkey/UIKit-cross-platform/pull/323)

## Note II
I want to add, that it might better to call `nativeDestroyScreen()` after `onNativeResize()` instead of the other way around now ([see here](https://github.com/flowkey/UIKit-cross-platform/blob/0e44ce485bf0e85fc161e1427970760dc2ff951e/src/main/java/org/libsdl/app/SDLActivity.kt#L315)). But anyway the order wouldn't really matter now with this fix in place (I guess) and also I'm not entirely sure if it would break something else.

## Note III
This should also fix some crashes we saw in `UIView`, where it accessed `UIScreen` when it was `null`.

### Screenrecording (before)

https://user-images.githubusercontent.com/2410252/109198589-b3340100-779e-11eb-889d-db70e457d980.mp4

### Screenrecording (fix)

https://user-images.githubusercontent.com/2410252/109198636-c0e98680-779e-11eb-961e-20eaa0d1c877.mp4




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
