### PR TITLE
clamp subview index _after_ removing from superview

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -206,9 +206,9 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
     /// Adds a subview without touching the view's layer or any of its sublayers.
     /// We need to be able to add layers at an index that isn't directly related to its subview index.
     private func insertSubviewWithoutTouchingLayer(_ view: UIView, at index: Int) {
+        if view.superview != nil { view.removeFromSuperview() }
         // ensure index is always in bounds:
         let index = max(subviews.startIndex, min(index, subviews.endIndex))
-        if view.superview != nil { view.removeFromSuperview() }
         subviews.insert(view, at: index)
         view.superview = self
     }


### PR DESCRIPTION
**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
#314 revealed another bug, where the subview index was not correctly bound-checked and could therefore cause a crash.




## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
