### PR TITLE
Fix insertSubviewWithoutTouchingLayer()

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -208,7 +208,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
     private func insertSubviewWithoutTouchingLayer(_ view: UIView, at index: Int) {
         // remove from superview without removing from superlayer
         if let oldSuperview = view.superview {
-            oldSuperview.subviews = oldSuperview.subviews.filter { $0 != view }
+            oldSuperview.subviews.removeAll(where: { $0 == view })
             view.superview = nil
             oldSuperview.setNeedsLayout()
         }
@@ -223,7 +223,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
         guard let superview = superview else { return }
         self.layer.removeFromSuperlayer()
 
-        superview.subviews = superview.subviews.filter { $0 != self }
+        superview.subviews.removeAll(where: { $0 == self })
         self.superview = nil
         superview.setNeedsLayout()
     }

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -206,7 +206,13 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
     /// Adds a subview without touching the view's layer or any of its sublayers.
     /// We need to be able to add layers at an index that isn't directly related to its subview index.
     private func insertSubviewWithoutTouchingLayer(_ view: UIView, at index: Int) {
-        if view.superview != nil { view.removeFromSuperview() }
+        // remove from superview without removing from superlayer
+        if let oldSuperview = view.superview {
+            oldSuperview.subviews = oldSuperview.subviews.filter { $0 != view }
+            view.superview = nil
+            oldSuperview.setNeedsLayout()
+        }
+
         // ensure index is always in bounds:
         let index = max(subviews.startIndex, min(index, subviews.endIndex))
         subviews.insert(view, at: index)


### PR DESCRIPTION
**Type of change:** Bug fix

## Motivation (current vs expected behavior)
Addresses a bug, where a views layer was mistakenly removed from the superlayer.





## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
