### PR TITLE
improve multilineSize for text calculations

### DIFF
--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -161,11 +161,7 @@ extension FontRenderer {
             tok = firstCharOfNextLine
         } while (tok < end)
 
-        // The sizing using linesCount is actually correct, but it gives a different result compared to
-        // what actually gets rendered. So for now, use this updated figure to have correct sizeThatFits etc:
-        let numberOfRandomExtraLinesRenderedBySDLTTF = 1
-        let linesCount = lines.count + numberOfRandomExtraLinesRenderedBySDLTTF
-
+        let linesCount = lines.count
         let combinedTextHeight = Int(textLineHeight) * linesCount
         let combinedLineSpacing = lineSpace * (linesCount - 1)
 

--- a/UIKitTests/UIFontTests.swift
+++ b/UIKitTests/UIFontTests.swift
@@ -29,8 +29,7 @@ class UIFontTests: XCTestCase {
         let calculatedSize = multilineText.size(with: testFont, wrapLength: wrapLength)
         XCTAssertEqual(calculatedSize.width, CGFloat(wrapLength))
 
-        let numberOfRandomExtraLinesRenderedBySDLTTF = UInt(1)
-        let numberOfLines = CGFloat(multilineText.numberOfLines() + numberOfRandomExtraLinesRenderedBySDLTTF)
+        let numberOfLines = CGFloat(multilineText.numberOfLines())
 
         // SDL_ttf adds an additional 2px per line on top of the font's line height
         // We are testing on retina devices, so 2px becomes 1px after reducing down:


### PR DESCRIPTION
**Type of change:** layouting fix

## Motivation (current vs expected behavior)

I noticed that there is too much space above and below UILabels especially when using bigger font sizes. Removing the hack `numberOfRandomExtraLinesRenderedBySDLTTF` seems to fix it. Maybe the rendering behaviour got fixed by updating `SDLTTF`?

**before:**

<img width="752" alt="Screenshot 2021-03-17 at 19 48 01" src="https://user-images.githubusercontent.com/5617793/111522288-67032d80-875a-11eb-9081-2f414e8301e1.png">

<img width="752" alt="Screenshot 2021-03-17 at 19 55 24" src="https://user-images.githubusercontent.com/5617793/111522622-c3664d00-875a-11eb-8739-39a06e18fdba.png">


**after:**
<img width="752" alt="Screenshot 2021-03-17 at 19 47 15" src="https://user-images.githubusercontent.com/5617793/111522299-6a96b480-875a-11eb-8103-fe1043232bdc.png">

<img width="752" alt="Screenshot 2021-03-17 at 19 43 06" src="https://user-images.githubusercontent.com/5617793/111522371-7d10ee00-875a-11eb-97a4-cda82fafd786.png">







## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
