### PR TITLE
prevent recursion when layouting parent from subview

### DIFF
--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -130,12 +130,12 @@ open class CALayer {
 
     open var bounds: CGRect = .zero {
         willSet(newBounds) {
+            guard newBounds != bounds else { return }
+            onWillSet(keyPath: .bounds)
+
             if previousBounds == nil {
                 previousBounds = bounds
             }
-
-            guard newBounds != bounds else { return }
-            onWillSet(keyPath: .bounds)
         }
     }
 

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -130,16 +130,16 @@ open class CALayer {
 
     open var bounds: CGRect = .zero {
         willSet(newBounds) {
-            guard newBounds != bounds else { return }
-            onWillSet(keyPath: .bounds)
-
-            if bounds.size != newBounds.size {
-                // It seems weird to access the superview here but it matches the iOS behaviour
-                (self.superlayer?.delegate as? UIView)?.setNeedsLayout()
+            if previousBounds == nil {
+                previousBounds = bounds
             }
 
+            guard newBounds != bounds else { return }
+            onWillSet(keyPath: .bounds)
         }
     }
+
+    internal var previousBounds: CGRect?
 
     public var opacity: Float = 1 {
         willSet(newOpacity) {

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -245,7 +245,6 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
         parentViewController?.viewWillLayoutSubviews()
         parentViewController?.viewDidLayoutSubviews()
-
     }
 
 

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -239,7 +239,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
         needsLayout = false
         
         if layer.previousBounds != nil && layer.previousBounds != layer.bounds {
-            (layer.superlayer?.delegate as? UIView)?.setNeedsDisplay()
+            (layer.superlayer?.delegate as? UIView)?.setNeedsLayout()
         }
         layer.previousBounds = nil
 

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -237,8 +237,15 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     open func layoutSubviews() {
         needsLayout = false
+        
+        if layer.previousBounds != nil && layer.previousBounds != layer.bounds {
+            (layer.superlayer?.delegate as? UIView)?.setNeedsDisplay()
+        }
+        layer.previousBounds = nil
+
         parentViewController?.viewWillLayoutSubviews()
         parentViewController?.viewDidLayoutSubviews()
+
     }
 
 


### PR DESCRIPTION
**Type of change:** performance improvement

## Motivation (current vs expected behavior)
I initially introduced this "weird bottom top" layout dependency in this commit https://github.com/flowkey/UIKit-cross-platform/commit/3ed2303e53d514a5b36127483bf3bb73c160cf7b. But I realised that this dependency causes expensive recursive relayouts at least in our player at the moment. We added a check to only relayout if the size has changed, but in our player implementation the size will always change (look at the example below)

It happens that `layoutSubviews` of the LearnstepNotification gets called a few hundred times initially and during learning again. The recursion is able to stop at some point, but I don't really know why it stops.

```swift
layoutSubviews {
    button.frame = container // changes bounds
    button.sizeToFit() // changes bounds again

   ....
 
   bodyLabel.bounds.size = CGSize(width: container.width, height: 0)
   bodyLabel.sizeToFit()

}
```






## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
