### PR TITLE
do not layout `superview.delegate` from presentation layer

### DIFF
--- a/Sources/CALayer+animations.swift
+++ b/Sources/CALayer+animations.swift
@@ -36,7 +36,7 @@ extension CALayer {
         if let animation = action(forKey: animationKey) as? CABasicAnimation,
             self.hasBeenRenderedInThisPartOfOverallLayerHierarchy
                 || animation.wasCreatedInUIAnimateBlock,
-            !self.disableAnimations,
+            !self.isPresentationForAnotherLayer,
             !CATransaction.disableActions()
         {
             add(animation, forKey: animationKey)
@@ -57,7 +57,7 @@ extension CALayer {
 
 extension CALayer {
     func animate(at currentTime: Timer) {
-        let presentation = createPresentation()
+        let presentation = _presentation ?? createPresentation()
 
         animations.forEach { (key, animation) in
             let animationProgress = animation.progress(for: currentTime)

--- a/Sources/CALayer+animations.swift
+++ b/Sources/CALayer+animations.swift
@@ -57,7 +57,7 @@ extension CALayer {
 
 extension CALayer {
     func animate(at currentTime: Timer) {
-        let presentation = _presentation ?? createPresentation()
+        let presentation = createPresentation()
 
         animations.forEach { (key, animation) in
             let animationProgress = animation.progress(for: currentTime)

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -133,7 +133,7 @@ open class CALayer {
             guard newBounds != bounds else { return }
             onWillSet(keyPath: .bounds)
 
-            if bounds.size != newBounds.size {
+            if !isPresentationForAnotherLayer && bounds.size != newBounds.size {
                 // It seems weird to access the superview here but it matches the iOS behaviour
                 (self.superlayer?.delegate as? UIView)?.setNeedsLayout()
             }
@@ -226,18 +226,17 @@ open class CALayer {
         return CALayer.defaultAction(forKey: event)
     }
 
-
     /// returns a non animating copy of the layer
     func createPresentation() -> CALayer {
         let copy = CALayer(layer: self)
-        copy.disableAnimations = true
+        copy.isPresentationForAnotherLayer = true
         return copy
     }
 
     internal var _presentation: CALayer?
     open func presentation() -> CALayer? { return _presentation }
 
-    internal var disableAnimations = false
+    internal var isPresentationForAnotherLayer = false
 
     internal var animations = [String: CABasicAnimation]() {
         didSet { onDidSetAnimations(wasEmpty: oldValue.isEmpty) }

--- a/UIKitTests/CALayerTests.swift
+++ b/UIKitTests/CALayerTests.swift
@@ -87,17 +87,15 @@ extension CALayerTests {
         let view = UIView()
         superView.addSubview(view)
         view.layer.bounds.size = CGSize(width: 10, height: 10)
-
         superView.layoutIfNeeded()
         view.layoutIfNeeded()
-
-        view.layer.bounds.size = CGSize(width: 15, height: 15)
 
         var didLayoutSubviews = false
         superView.onLayoutSubviews = {
             didLayoutSubviews = true
         }
 
+        view.layer.bounds.size = CGSize(width: 15, height: 15)
         superView.layoutIfNeeded()
         XCTAssertEqual(didLayoutSubviews, true)
     }
@@ -107,17 +105,15 @@ extension CALayerTests {
         let view = UIView()
         superView.addSubview(view)
         view.layer.bounds.size = CGSize(width: 10, height: 10)
-
         superView.layoutIfNeeded()
         view.layoutIfNeeded()
-
-        view.layer.presentation()?.bounds.size = CGSize(width: 15, height: 15)
 
         var didLayoutSubviews = false
         superView.onLayoutSubviews = {
             didLayoutSubviews = true
         }
 
+        view.layer.presentation()?.bounds.size = CGSize(width: 15, height: 15)
         superView.layoutIfNeeded()
         XCTAssertEqual(didLayoutSubviews, false)
     }
@@ -127,17 +123,15 @@ extension CALayerTests {
         let view = UIScrollView()
         superView.addSubview(view)
         view.contentOffset = CGPoint(x: 100, y: 100)
-
         superView.layoutIfNeeded()
         view.layoutIfNeeded()
-
-        view.contentOffset = CGPoint(x: 200, y: 200)
 
         var didLayoutSubviews = false
         superView.onLayoutSubviews = {
             didLayoutSubviews = true
         }
 
+        view.contentOffset = CGPoint(x: 200, y: 200)
         superView.layoutIfNeeded()
         XCTAssertEqual(didLayoutSubviews, false)
     }

--- a/UIKitTests/CALayerTests.swift
+++ b/UIKitTests/CALayerTests.swift
@@ -69,18 +69,22 @@ class CALayerTests: XCTestCase {
         XCTAssertEqual(layer.frame.origin.x, expectedSize.width, accuracy: accuracy)
         XCTAssertEqual(layer.frame.origin.y, expectedSize.height, accuracy: accuracy)
     }
+}
+
+extension CALayerTests {
+    class ViewWithLayoutCallback: UIView {
+        var onLayoutSubviews: (() -> ())?
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            onLayoutSubviews?()
+        }
+    }
+
 
     func testLayoutSuperlayerDelegateWhenChangingBoundsSize() {
-        class TestView: UIView {
-            var onLayoutSubviews: (() -> ())?
-            override func layoutSubviews() {
-                super.layoutSubviews()
-                onLayoutSubviews?()
-            }
-        }
-
-        let superView = TestView()
-        let view = TestView()
+        let superView = ViewWithLayoutCallback()
+        let view = UIView()
         superView.addSubview(view)
         view.layer.bounds.size = CGSize(width: 10, height: 10)
 
@@ -99,16 +103,8 @@ class CALayerTests: XCTestCase {
     }
 
     func testDoesNotLayoutSuperlayerDelegateWhenChangingBoundsSizeOfPresentation() {
-        class TestView: UIView {
-            var onLayoutSubviews: (() -> ())?
-            override func layoutSubviews() {
-                super.layoutSubviews()
-                onLayoutSubviews?()
-            }
-        }
-
-        let superView = TestView()
-        let view = TestView()
+        let superView = ViewWithLayoutCallback()
+        let view = UIView()
         superView.addSubview(view)
         view.layer.bounds.size = CGSize(width: 10, height: 10)
 
@@ -127,15 +123,7 @@ class CALayerTests: XCTestCase {
     }
 
     func testDoesNotLayoutSuperlayerDelegateWhenChangingContentOffsetOfSCrollView() {
-        class TestView: UIView {
-            var onLayoutSubviews: (() -> ())?
-            override func layoutSubviews() {
-                super.layoutSubviews()
-                onLayoutSubviews?()
-            }
-        }
-
-        let superView = TestView()
+        let superView = ViewWithLayoutCallback()
         let view = UIScrollView()
         superView.addSubview(view)
         view.contentOffset = CGPoint(x: 100, y: 100)

--- a/UIKitTests/CALayerTests.swift
+++ b/UIKitTests/CALayerTests.swift
@@ -69,4 +69,88 @@ class CALayerTests: XCTestCase {
         XCTAssertEqual(layer.frame.origin.x, expectedSize.width, accuracy: accuracy)
         XCTAssertEqual(layer.frame.origin.y, expectedSize.height, accuracy: accuracy)
     }
+
+    func testLayoutSuperlayerDelegateWhenChangingBoundsSize() {
+        class TestView: UIView {
+            var onLayoutSubviews: (() -> ())?
+            override func layoutSubviews() {
+                super.layoutSubviews()
+                onLayoutSubviews?()
+            }
+        }
+
+        let superView = TestView()
+        let view = TestView()
+        superView.addSubview(view)
+        view.layer.bounds.size = CGSize(width: 10, height: 10)
+
+        superView.layoutIfNeeded()
+        view.layoutIfNeeded()
+
+        view.layer.bounds.size = CGSize(width: 15, height: 15)
+
+        var didLayoutSubviews = false
+        superView.onLayoutSubviews = {
+            didLayoutSubviews = true
+        }
+
+        superView.layoutIfNeeded()
+        XCTAssertEqual(didLayoutSubviews, true)
+    }
+
+    func testDoesNotLayoutSuperlayerDelegateWhenChangingBoundsSizeOfPresentation() {
+        class TestView: UIView {
+            var onLayoutSubviews: (() -> ())?
+            override func layoutSubviews() {
+                super.layoutSubviews()
+                onLayoutSubviews?()
+            }
+        }
+
+        let superView = TestView()
+        let view = TestView()
+        superView.addSubview(view)
+        view.layer.bounds.size = CGSize(width: 10, height: 10)
+
+        superView.layoutIfNeeded()
+        view.layoutIfNeeded()
+
+        view.layer.presentation()?.bounds.size = CGSize(width: 15, height: 15)
+
+        var didLayoutSubviews = false
+        superView.onLayoutSubviews = {
+            didLayoutSubviews = true
+        }
+
+        superView.layoutIfNeeded()
+        XCTAssertEqual(didLayoutSubviews, false)
+    }
+
+    func testDoesNotLayoutSuperlayerDelegateWhenChangingContentOffsetOfSCrollView() {
+        class TestView: UIView {
+            var onLayoutSubviews: (() -> ())?
+            override func layoutSubviews() {
+                super.layoutSubviews()
+                onLayoutSubviews?()
+            }
+        }
+
+        let superView = TestView()
+        let view = UIScrollView()
+        superView.addSubview(view)
+        view.contentOffset = CGPoint(x: 100, y: 100)
+
+        superView.layoutIfNeeded()
+        view.layoutIfNeeded()
+
+        view.contentOffset = CGPoint(x: 200, y: 200)
+
+        var didLayoutSubviews = false
+        superView.onLayoutSubviews = {
+            didLayoutSubviews = true
+        }
+
+        superView.layoutIfNeeded()
+        XCTAssertEqual(didLayoutSubviews, false)
+    }
 }


### PR DESCRIPTION
**Type of change:** performance improvement

## Motivation (current vs expected behavior)
This is a follow up based on https://github.com/flowkey/UIKit-cross-platform/pull/328.

I noticed that the recursive relayouting only happens when wrapping the layout code in an animation block. During this animation in the learnstep we mutate bounds of the presentation on every frame which then triggers layouting for the parent view for each frame as well. I think this matches the ios behaviour.





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
