### PR TITLE
fix multiline text size calculcation

### DIFF
--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -97,17 +97,17 @@ extension FontRenderer {
     }
 
     internal func multilineSize(of text: String, wrapLength: UInt) -> CGSize {
-        return multilineSize(of: text, textLength: Int32(text.count), wrapLength: Int(wrapLength))
+        return multilineSize(of: text, wrapLength: Int(wrapLength))
     }
 
-    private func multilineSize(of text: UnsafePointer<CChar>, textLength: Int32, wrapLength: Int) -> CGSize {
+    private func multilineSize(of text: UnsafePointer<CChar>, wrapLength: Int) -> CGSize {
         guard wrapLength > 0 else { return .zero }
         let lineSpace = 2
 
         var textLineHeight: Int32 = 0
 
         var tok = UnsafeMutablePointer(mutating: text)
-        let end = tok + Int(textLength)
+        let end = tok + SDL_strlen(text)
 
         var lines = [UnsafeMutablePointer<CChar>]()
         repeat {
@@ -118,7 +118,7 @@ extension FontRenderer {
             var searchIndex =
                 strchr(tok, newLineR) ??
                     strchr(tok, newLineN) ??
-                    end.advanced(by: -1)
+                    end
 
             var firstCharOfNextLine = searchIndex + 1
 

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -15,18 +15,12 @@ class ViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        label.text = "Lorem Ipsum is simply dummy text1"
-        label.numberOfLines = 2
-        label.font = .systemFont(ofSize: 40)
-        label.backgroundColor = .red
+        label.text = "Hello World"
+        label.font = .systemFont(ofSize: 30)
+        label.sizeToFit()
+        label.center = view.center
 
         view.backgroundColor = UIColor(red: 0 / 255, green: 206 / 255, blue: 201 / 255, alpha: 1)
         view.addSubview(label)
-    }
-
-    override func viewDidLayoutSubviews() {
-        label.frame.width = view.bounds.width
-        label.center = view.center
-        label.sizeToFit()
     }
 }

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -15,12 +15,18 @@ class ViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        label.text = "Hello World"
-        label.font = .systemFont(ofSize: 30)
-        label.sizeToFit()
-        label.center = view.center
+        label.text = "Lorem Ipsum is simply dummy text1"
+        label.numberOfLines = 2
+        label.font = .systemFont(ofSize: 40)
+        label.backgroundColor = .red
 
         view.backgroundColor = UIColor(red: 0 / 255, green: 206 / 255, blue: 201 / 255, alpha: 1)
         view.addSubview(label)
+    }
+
+    override func viewDidLayoutSubviews() {
+        label.frame.width = view.bounds.width
+        label.center = view.center
+        label.sizeToFit()
     }
 }


### PR DESCRIPTION
Fixes https://app.asana.com/0/1190553484415965/1200141498205813

**Type of change:** bugfix

## Motivation (current vs expected behavior)
There is a bug in the text rendering logic, where the frame of a UILabel does not match with the actual surface being rendered by SDL_TTF. This happens when the text renders very close to the right edge of the frame.

I revisited the code in `TTF_RenderUTF8_Blended_Wrapped` and found a minor difference there with what we have in the font renderer.

#### broken:
<img width="752" alt="Screenshot 2021-04-06 at 18 55 47" src="https://user-images.githubusercontent.com/5617793/113760768-edd27700-9716-11eb-829b-a752455aa535.png">

<img width="752" alt="Screenshot 2021-04-06 at 20 22 12" src="https://user-images.githubusercontent.com/5617793/113763174-aac5d300-9719-11eb-866f-1fade3de4478.png">


#### fixed
<img width="752" alt="Screenshot 2021-04-06 at 20 31 02" src="https://user-images.githubusercontent.com/5617793/113760875-13f81700-9717-11eb-9c15-1fd020036ecd.png">







## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
