### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/flowkey/UIKit-cross-platform.svg?style=shield&circle-token=2bc60653f4bb369754b04d97d324d9ba2bee6c6b)](https://circleci.com/gh/flowkey/UIKit-cross-platform)
-[![Swift4.1](https://img.shields.io/badge/swift-4.1-orange.svg?style=flat)](https://swift.org/)
+[![Swift5.1](https://img.shields.io/badge/swift-5.1-orange.svg?style=flat)](https://swift.org/)
 [![Platforms](https://img.shields.io/badge/platform-Android%20%7C%20macOS-lightgrey.svg)](https://swift.org/)
 [![License](https://img.shields.io/badge/license-MIT-71787A.svg)](https://tldrlegal.com/license/mit-license)
 [![codecov](https://codecov.io/gh/flowkey/UIKit-cross-platform/branch/master/graph/badge.svg?token=7pkfn9WaxE)](https://codecov.io/gh/flowkey/UIKit-cross-platform)
@@ -70,7 +70,7 @@ brew install cmake && brew install ninja
 
 UIKit-cross-platform renders with [SDL_gpu](https://github.com/grimfang4/sdl-gpu) which translates down to lower-level [OpenGL](https://www.opengl.org/) instructions.
 
-On Android, [Swift Package Manager](https://github.com/apple/swift-package-manager) compiles Swift Code into native binaries, which are called through the [NDK](https://developer.android.com/ndk/).
+On Android, [CMake](https://cmake.org/) compiles Swift Code into native binaries via [Ninja](https://ninja-build.org/), which are called through the [NDK](https://developer.android.com/ndk/).
 
 [More detailed information about the architecture can be found here](docs/ARCHITECTURE.md)
 


### PR DESCRIPTION


**Type of change:** docs

## Motivation (current vs expected behavior)
- refer swift 5.1 badge
- remove swift package manager from readme, reference cmake and ninja





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
