### PR TITLE
Fix build for macOS with XCode 13

### DIFF
--- a/Sources/CAMediaTimingFunction.swift
+++ b/Sources/CAMediaTimingFunction.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-#if os(Android) || os(Linux)
-import func Foundation.pow
-#endif
+import Foundation
 
 public let kCAMediaTimingFunctionLinear = "linear"
 public let kCAMediaTimingFunctionEaseIn = "easeIn"

--- a/Sources/CAMediaTimingFunction.swift
+++ b/Sources/CAMediaTimingFunction.swift
@@ -6,7 +6,9 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
+#if os(Android) || os(Linux)
 import func Foundation.pow
+#endif
 
 public let kCAMediaTimingFunctionLinear = "linear"
 public let kCAMediaTimingFunctionEaseIn = "easeIn"

--- a/Sources/UIColor.swift
+++ b/Sources/UIColor.swift
@@ -52,8 +52,8 @@ public class UIColor: NSObject/*, Hashable*/ {
     // XXX: This is not currently working as it should but it is better than nothing
     // We currently only use this in testing, but whoever needs it for real should have a look at fixing it..
     public convenience init(hue: CGFloat, saturation: CGFloat, brightness: CGFloat, alpha: CGFloat) {
-        let c = (1 - ((2 * brightness) - 1).magnitude) * saturation
-        let x = c * (1 - (hue.remainder(dividingBy: 2) - 1).magnitude)
+        let c: CGFloat = (1 - ((2 * brightness) - 1).magnitude) * saturation
+        let x: CGFloat = c * (1 - (hue.remainder(dividingBy: 2) - 1).magnitude)
 
         let m = brightness - (0.5 * c)
 

--- a/Sources/UIScrollView+velocity.swift
+++ b/Sources/UIScrollView+velocity.swift
@@ -6,8 +6,13 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
+#if os(Android) || os(Linux)
 import func Foundation.sqrt
 import func Foundation.log
+#else
+// use Darwin.log and Darwin.pow
+#endif
+
 
 private extension CGPoint {
     var magnitude: CGFloat {

--- a/Sources/UIScrollView+velocity.swift
+++ b/Sources/UIScrollView+velocity.swift
@@ -6,13 +6,7 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-#if os(Android) || os(Linux)
-import func Foundation.sqrt
-import func Foundation.log
-#else
-// use Darwin.log and Darwin.pow
-#endif
-
+import Foundation
 
 private extension CGPoint {
     var magnitude: CGFloat {


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
Got some compiler errors when building for macOS with XCode13. For some reason importing the whole Foundation module instead of just the required functions fixes the issue.

<img width="976" alt="Screenshot 2021-09-29 at 13 34 05" src="https://user-images.githubusercontent.com/2410252/135269991-237b806e-2399-48f0-8bbc-4f74d89f4fab.png">
<img width="1022" alt="Screenshot 2021-09-29 at 13 14 31" src="https://user-images.githubusercontent.com/2410252/135270003-f5352dce-6df8-4b5a-acd7-8314c13f2c22.png">






## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
