### PR TITLE
Update ExoPlayer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,10 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.android.exoplayer:exoplayer:2.11.7"
+    implementation "com.google.android.exoplayer:exoplayer:2.13.3"
 }
 
 repositories {
+    mavenCentral()
     google()
 }

--- a/samples/getting-started/android/build.gradle
+++ b/samples/getting-started/android/build.gradle
@@ -1,10 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
@@ -18,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
**Type of change:** maintenance

## Motivation (current vs expected behavior)
Update ExoPlayer to the [earliest version available on Maven](https://mvnrepository.com/artifact/com.google.android.exoplayer/exoplayer) and kick jcenter().
Replace all of the deprecated API calls.



## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
