### PR TITLE
Fix surfaceCreated() override

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -247,7 +247,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
         mSurface.setOnTouchListener(this)
     }
 
-    override fun surfaceCreated(holder: SurfaceHolder?) {
+    override fun surfaceCreated(holder: SurfaceHolder) {
         Log.v(TAG, "surfaceCreated()")
         mHasFocus = hasFocus()
 


### PR DESCRIPTION
**Type of change:** build issue fix

## Motivation (current vs expected behavior)
It seems that we incorrectly overrode the [`surfaceCreated` callback ](https://developer.android.com/reference/android/view/SurfaceHolder.Callback#surfaceCreated(android.view.SurfaceHolder)) in our SDLActivity.kt:

```
Error: Command failed: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
e: /UIKit/src/main/java/org/libsdl/app/SDLActivity.kt: (23, 6): Class 'SDLActivity' is not abstract and does not implement abstract member public abstract fun surfaceCreated(p0: SurfaceHolder): Unit defined in android.view.SurfaceHolder.Callback
e: /UIKit/src/main/java/org/libsdl/app/SDLActivity.kt: (250, 5): 'surfaceCreated' overrides nothing

FAILURE: Build failed with an exception.
```

It could be that the error suddenly occured while updating the target api level to 30.



## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
