### PR TITLE
Call presented UIViewController lifecycle methods from UINavigationController

### DIFF
--- a/Sources/CAMediaTimingFunction.swift
+++ b/Sources/CAMediaTimingFunction.swift
@@ -51,14 +51,14 @@ extension CAMediaTimingFunction {
     static func easeInQuad(_ x: CGFloat) -> CGFloat { return pow(x, 2) }
     static func easeOutQuad(_ x: CGFloat) -> CGFloat { return x * (2 - x) }
     static func easeInOutCubic(_ x: CGFloat) -> CGFloat {
-        return x < 0.5 ? 2 * pow(x, 2) : -1 + (4 - 2 * x) * x
+        return x < 0.5 ? 2 * (x * x) : -1 + (4 - 2 * x) * x
     }
 
     // from CubicBezier1D optimising away constant terms
     static func customEaseOut(_ x: CGFloat) -> CGFloat {
         let term1 = UIScrollViewDecelerationRateNormal * 3 * x * pow(1 - x, 2)
-        let term2 = 3 * pow(x, 2) * (1 - x)
-        let term3 = pow(x, 3)
+        let term2 = 3 * (x * x) * (1 - x)
+        let term3 = x * x * x
 
         return term1 + term2 + term3
     }

--- a/Sources/UINavigationBarAndroid.swift
+++ b/Sources/UINavigationBarAndroid.swift
@@ -27,7 +27,12 @@ open class UINavigationBarAndroid: UINavigationBar {
                 originalLeftButtonOnPress?()
             } else {
                 // We are the last item, or there are no items. Dismiss!
-                (self?.next as? UINavigationController)?.dismiss(animated: true)
+                if
+                    let navigationController = self?.next as? UINavigationController,
+                    navigationController !== UIApplication.shared.keyWindow?.rootViewController
+                {
+                    navigationController.dismiss(animated: true)
+                }
             }
         }
 

--- a/Sources/UINavigationBarAndroid.swift
+++ b/Sources/UINavigationBarAndroid.swift
@@ -27,10 +27,7 @@ open class UINavigationBarAndroid: UINavigationBar {
                 originalLeftButtonOnPress?()
             } else {
                 // We are the last item, or there are no items. Dismiss!
-                if
-                    let navigationController = self?.next as? UINavigationController,
-                    navigationController !== UIApplication.shared.keyWindow?.rootViewController
-                {
+                if let navigationController = self?.next as? UINavigationController {
                     navigationController.dismiss(animated: true)
                 }
             }

--- a/Sources/UINavigationController.swift
+++ b/Sources/UINavigationController.swift
@@ -65,7 +65,7 @@ open class UINavigationController: UIViewController {
     }
 
     open override func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
-        if self === UIApplication.shared.keyWindow?.rootViewController {
+        guard self !== UIApplication.shared.keyWindow?.rootViewController else {
             completion?()
             return
         }

--- a/Sources/UINavigationController.swift
+++ b/Sources/UINavigationController.swift
@@ -65,6 +65,11 @@ open class UINavigationController: UIViewController {
     }
 
     open override func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
+        if self === UIApplication.shared.keyWindow?.rootViewController {
+            completion?()
+            return
+        }
+
         let topOfStack = viewControllers.last
         topOfStack?.viewWillDisappear(animated)
 

--- a/Sources/UINavigationController.swift
+++ b/Sources/UINavigationController.swift
@@ -33,6 +33,7 @@ open class UINavigationController: UIViewController {
 
     private func updateUIFromViewControllerStack(animated: Bool) {
         guard _view != nil else { return }
+        if presentedViewController === viewControllers.last { return }
 
         transitionView.subviews.forEach { $0.removeFromSuperview() }
         presentedViewController = viewControllers.last
@@ -40,7 +41,9 @@ open class UINavigationController: UIViewController {
         if let viewOnTopOfStack = viewControllers.last?.view {
             // TODO: Animate here
             viewOnTopOfStack.frame = transitionView.bounds
+            presentedViewController?.viewWillAppear(animated)
             transitionView.addSubview(viewOnTopOfStack)
+            presentedViewController?.viewDidAppear(animated)
         }
     }
 

--- a/Sources/UINavigationController.swift
+++ b/Sources/UINavigationController.swift
@@ -65,7 +65,7 @@ open class UINavigationController: UIViewController {
     }
 
     open override func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
-        guard self !== UIApplication.shared.keyWindow?.rootViewController else {
+        guard self !== UIApplication.shared?.keyWindow?.rootViewController else {
             completion?()
             return
         }

--- a/samples/getting-started/DemoApp/AppDelegate.swift
+++ b/samples/getting-started/DemoApp/AppDelegate.swift
@@ -25,4 +25,3 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/samples/getting-started/DemoApp/AppDelegate.swift
+++ b/samples/getting-started/DemoApp/AppDelegate.swift
@@ -19,7 +19,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
 
         window = UIWindow()
-        window?.rootViewController = ViewController()
+        window?.rootViewController = UINavigationController(rootViewController: ViewController())
         window?.makeKeyAndVisible()
 
         return true


### PR DESCRIPTION
Fixes #341 

**Type of change:** Bug fix

## Motivation (current vs expected behavior)

As reported in #341, UINavigationController does not work as expected. This is because `viewWillAppear` (etc.) are never called there. I have added a call to `viewWillAppear` and `viewDidAppear`, but there are probably other lifecycle methods that are currently not being called.





## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
