### PR TITLE
Reduce dependency on Foundation

### DIFF
--- a/Sources/AVPlayer+Android.swift
+++ b/Sources/AVPlayer+Android.swift
@@ -9,12 +9,14 @@
 import JNI
 
 public class AVPlayer: JNIObject {
+    public override static var className: String { "org.uikit.AVPlayer" }
+
     public var onLoaded: ((Error?) -> Void)?
     public var onVideoEnded: (() -> Void)?
 
     public convenience init(playerItem: AVPlayerItem) {
         let parentView = JavaSDLView(getSDLView())
-        try! self.init("org.uikit.AVPlayer", arguments: [parentView, playerItem.asset])
+        try! self.init(arguments: parentView, playerItem.asset)
         globalAVPlayer = self
     }
 

--- a/Sources/AVPlayerLayer+Android.swift
+++ b/Sources/AVPlayerLayer+Android.swift
@@ -7,13 +7,13 @@
 //
 
 import JNI
-import func Foundation.round // For rounding CGFloats in .frame
 
 public class AVPlayerLayer: JNIObject {
+    override public static var className: String { "org.uikit.AVPlayerLayer" }
 
     public convenience init(player: AVPlayer) {
         let parentView = JavaSDLView(getSDLView())
-        try! self.init("org.uikit.AVPlayerLayer", arguments: [parentView, player])
+        try! self.init(arguments: parentView, player)
     }
 
     public var frame: CGRect {
@@ -21,10 +21,10 @@ public class AVPlayerLayer: JNIObject {
         set {
             let scaledFrame = (newValue * UIScreen.main.scale)
             try! call(methodName: "setFrame", arguments: [
-                JavaInt(round(scaledFrame.origin.x)),
-                JavaInt(round(scaledFrame.origin.y)),
-                JavaInt(round(scaledFrame.size.width)),
-                JavaInt(round(scaledFrame.size.height))
+                JavaInt(scaledFrame.origin.x.rounded()),
+                JavaInt(scaledFrame.origin.y.rounded()),
+                JavaInt(scaledFrame.size.width.rounded()),
+                JavaInt(scaledFrame.size.height.rounded())
             ])
         }
     }

--- a/Sources/AVURLAsset+Android.swift
+++ b/Sources/AVURLAsset+Android.swift
@@ -17,9 +17,11 @@ public class AVPlayerItem {
 }
 
 public class AVURLAsset: JNIObject {
+    public override static var className: String { "org.uikit.AVURLAsset" }
+
     public var url: URL?
     convenience public init(url: URL) {
-        try! self.init("org.uikit.AVURLAsset", arguments: [JavaSDLView(getSDLView()), url.absoluteString])
+        try! self.init(arguments: JavaSDLView(getSDLView()), url.absoluteString)
         self.url = url
     }
 }

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -299,7 +299,7 @@ extension CALayer: Hashable {
     }
 }
 
-public protocol CALayerDelegate: class {
+public protocol CALayerDelegate: AnyObject {
     func action(forKey event: String) -> CABasicAnimation?
     func display(_ layer: CALayer)
 }

--- a/Sources/CAMediaTimingFunction.swift
+++ b/Sources/CAMediaTimingFunction.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import Foundation
-
 public let kCAMediaTimingFunctionLinear = "linear"
 public let kCAMediaTimingFunctionEaseIn = "easeIn"
 public let kCAMediaTimingFunctionEaseOut = "easeOut"
@@ -43,12 +41,12 @@ public class CAMediaTimingFunction {
 
 extension CAMediaTimingFunction {
     static func linear(_ x: CGFloat) -> CGFloat { return x }
-    static func easeInCubic(_ x: CGFloat) -> CGFloat { return pow(x, 3) }
+    static func easeInCubic(_ x: CGFloat) -> CGFloat { return x * x * x }
     static func easeOutCubic(_ x: CGFloat) -> CGFloat { 
         let t = x - 1
         return ((t * t * t) + 1)
     }
-    static func easeInQuad(_ x: CGFloat) -> CGFloat { return pow(x, 2) }
+    static func easeInQuad(_ x: CGFloat) -> CGFloat { return x * x }
     static func easeOutQuad(_ x: CGFloat) -> CGFloat { return x * (2 - x) }
     static func easeInOutCubic(_ x: CGFloat) -> CGFloat {
         return x < 0.5 ? 2 * (x * x) : -1 + (4 - 2 * x) * x
@@ -56,7 +54,7 @@ extension CAMediaTimingFunction {
 
     // from CubicBezier1D optimising away constant terms
     static func customEaseOut(_ x: CGFloat) -> CGFloat {
-        let term1 = UIScrollViewDecelerationRateNormal * 3 * x * pow(1 - x, 2)
+        let term1 = UIScrollViewDecelerationRateNormal * 3 * x * (1 - x) * (1 - x)
         let term2 = 3 * (x * x) * (1 - x)
         let term3 = x * x * x
 

--- a/Sources/CAMediaTimingFunction.swift
+++ b/Sources/CAMediaTimingFunction.swift
@@ -51,14 +51,14 @@ extension CAMediaTimingFunction {
     static func easeInQuad(_ x: CGFloat) -> CGFloat { return pow(x, 2) }
     static func easeOutQuad(_ x: CGFloat) -> CGFloat { return x * (2 - x) }
     static func easeInOutCubic(_ x: CGFloat) -> CGFloat {
-        return x < 0.5 ? 2 * pow(x, 2) : -1 + (4 - 2 * x) * x
+        return x < 0.5 ? 2 * (x * x) : -1 + (4 - 2 * x) * x
     }
 
     // from CubicBezier1D optimising away constant terms
     static func customEaseOut(_ x: CGFloat) -> CGFloat {
         let term1 = UIScrollViewDecelerationRateNormal * 3 * x * pow(1 - x, 2)
-        let term2 = 3 * pow(x, 2) * (1 - x)
-        let term3 = pow(x, 3)
+        let term2 = 3 * (x * x) * (1 - x)
+        let term3 = x * x * x
 
         return term1 + term2 + term3
     }

--- a/Sources/CATransform3D.swift
+++ b/Sources/CATransform3D.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
-
 public struct CATransform3D {
     public init(
         m11: Float, m12: Float, m13: Float, m14: Float,
@@ -49,12 +47,16 @@ extension CATransform3D {
 
 internal extension CATransform3D {
     func transformingVector(x: CGFloat, y: CGFloat, z: CGFloat) -> (x: CGFloat, y: CGFloat, z: CGFloat) {
-        let newX = CGFloat(m11) * x + CGFloat(m21) * y + CGFloat(m31) * z + CGFloat(m41)
-        let newY = CGFloat(m12) * x + CGFloat(m22) * y + CGFloat(m32) * z + CGFloat(m42)
-        let newZ = CGFloat(m13) * x + CGFloat(m23) * y + CGFloat(m33) * z + CGFloat(m43)
-        let newW = CGFloat(m14) * x + CGFloat(m24) * y + CGFloat(m34) * z + CGFloat(m44)
+        let newX = Double(m11) * Double(x) + Double(m21) * Double(y) + Double(m31) * Double(z) + Double(m41)
+        let newY = Double(m12) * Double(x) + Double(m22) * Double(y) + Double(m32) * Double(z) + Double(m42)
+        let newZ = Double(m13) * Double(x) + Double(m23) * Double(y) + Double(m33) * Double(z) + Double(m43)
+        let newW = Double(m14) * Double(x) + Double(m24) * Double(y) + Double(m34) * Double(z) + Double(m44)
 
-        return (x: newX / newW, y: newY / newW, z: newZ / newW)
+        return (
+            x: CGFloat(newX / newW),
+            y: CGFloat(newY / newW),
+            z: CGFloat(newZ / newW)
+        )
     }
 }
 

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -8,7 +8,7 @@
 
 import SDL
 import SDL_gpu
-import Foundation
+import struct Foundation.Data
 
 public class CGImage {
     /// Be careful using this pointer e.g. for another CGImage instance.
@@ -50,10 +50,13 @@ public class CGImage {
 
     internal convenience init?(_ sourceData: Data) {
         var data = sourceData
-        let dataCount = Int32(data.count)
 
-        guard let gpuImagePtr = data.withUnsafeMutableBytes({ (ptr: UnsafeMutablePointer<Int8>) -> UnsafeMutablePointer<GPU_Image>? in
-            let rw = SDL_RWFromMem(ptr, dataCount)
+        guard let gpuImagePtr = data.withUnsafeMutableBytes({ buffer -> UnsafeMutablePointer<GPU_Image>? in
+            guard let ptr = buffer.baseAddress?.assumingMemoryBound(to: Int8.self) else {
+                return nil
+            }
+
+            let rw = SDL_RWFromMem(ptr, Int32(buffer.count))
             return GPU_LoadImage_RW(rw, true)
         }) else { return nil }
 

--- a/Sources/Data+fromRelativePathCrossPlatform.swift
+++ b/Sources/Data+fromRelativePathCrossPlatform.swift
@@ -6,7 +6,8 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
+import struct Foundation.Data
+import struct Foundation.URL
 
 extension Data {
     public static func _fromPathCrossPlatform(_ path: String) -> Data? {

--- a/Sources/FontRenderer+singleLineSize.swift
+++ b/Sources/FontRenderer+singleLineSize.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
 import SDL_ttf
+import class Foundation.NSAttributedString
 
 extension FontRenderer {
     func singleLineSize(of attributedString: NSAttributedString) -> CGSize {

--- a/Sources/NSAttributedStringKey.swift
+++ b/Sources/NSAttributedStringKey.swift
@@ -7,7 +7,7 @@
 //
 
 #if os(Android)
-import Foundation
+import class Foundation.NSAttributedString
 
 extension NSAttributedString.Key {
     public static let kern = NSAttributedString.Key(rawValue: "NSKern")

--- a/Sources/Shader.swift
+++ b/Sources/Shader.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import Foundation
 import SDL_gpu
-
 
 class VertexShader: Shader {
     // Some keywords have changed since the earlier shader language versions available on Android:

--- a/Sources/UIAlertController.swift
+++ b/Sources/UIAlertController.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import func Foundation.round
-
 public enum UIAlertControllerStyle {
     case actionSheet
     case popover
@@ -62,8 +60,8 @@ public class UIAlertController: UIViewController {
         )
 
         self.alertControllerView?.center = CGPoint(
-            x: round(self.view.bounds.midX),
-            y: round(self.view.bounds.midY)
+            x: self.view.bounds.midX.rounded(),
+            y: self.view.bounds.midY.rounded()
         )
     }
 

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -7,7 +7,6 @@
 //
 
 import SDL
-import struct Foundation.TimeInterval
 
 extension UIApplication {
     func handleEventsIfNeeded() {
@@ -146,9 +145,9 @@ extension SDL_Scancode {
 extension SDL_Keymod: OptionSet {}
 
 extension SDL_Event {
-    var timestampInSeconds: TimeInterval {
+    var timestampInSeconds: Double {
         // SDL timestamps are in milliseconds intially:
-        return TimeInterval(self.common.timestamp) / 1000
+        return Double(self.common.timestamp) / 1000
     }
 }
 

--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
 import SDL
 
 open class UIApplication {

--- a/Sources/UIApplicationDelegate.swift
+++ b/Sources/UIApplicationDelegate.swift
@@ -16,7 +16,7 @@ public extension UIApplication {
 }
 
 
-public protocol UIApplicationDelegate: class {
+public protocol UIApplicationDelegate: AnyObject {
     init()
     var window: UIWindow? { get set }
 

--- a/Sources/UIApplicationMain+Mac.swift
+++ b/Sources/UIApplicationMain+Mac.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
 import CoreVideo
 
 let displayID = CGMainDisplayID()

--- a/Sources/UIApplicationMain.swift
+++ b/Sources/UIApplicationMain.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2018 flowkey. All rights reserved.
 //
 
-import Foundation
 import SDL
+import func Foundation.NSClassFromString
 
 @discardableResult
 public func UIApplicationMain(_ argc: Int32, _ argv: UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>, _ principalClassName: String?, _ delegateClassName: String?) -> Int32 {

--- a/Sources/UIGestureRecognizerDelegate.swift
+++ b/Sources/UIGestureRecognizerDelegate.swift
@@ -11,7 +11,7 @@
 //    @objc optional func someFunc()
 //}
 
-public protocol UIGestureRecognizerDelegate: class {
+public protocol UIGestureRecognizerDelegate: AnyObject {
 //    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool
 
 //    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive: UITouch) -> Bool

--- a/Sources/UIImage.swift
+++ b/Sources/UIImage.swift
@@ -8,7 +8,8 @@
 
 import SDL
 import SDL_gpu
-import Foundation
+import struct Foundation.Data
+import class Foundation.NSString
 
 public class UIImage {
     public let cgImage: CGImage

--- a/Sources/UINavigationBarAndroid.swift
+++ b/Sources/UINavigationBarAndroid.swift
@@ -27,7 +27,12 @@ open class UINavigationBarAndroid: UINavigationBar {
                 originalLeftButtonOnPress?()
             } else {
                 // We are the last item, or there are no items. Dismiss!
-                (self?.next as? UINavigationController)?.dismiss(animated: true)
+                if
+                    let navigationController = self?.next as? UINavigationController,
+                    navigationController !== UIApplication.shared.keyWindow?.rootViewController
+                {
+                    navigationController.dismiss(animated: true)
+                }
             }
         }
 

--- a/Sources/UINavigationController.swift
+++ b/Sources/UINavigationController.swift
@@ -33,6 +33,7 @@ open class UINavigationController: UIViewController {
 
     private func updateUIFromViewControllerStack(animated: Bool) {
         guard _view != nil else { return }
+        if presentedViewController === viewControllers.last { return }
 
         transitionView.subviews.forEach { $0.removeFromSuperview() }
         presentedViewController = viewControllers.last
@@ -40,7 +41,9 @@ open class UINavigationController: UIViewController {
         if let viewOnTopOfStack = viewControllers.last?.view {
             // TODO: Animate here
             viewOnTopOfStack.frame = transitionView.bounds
+            presentedViewController?.viewWillAppear(animated)
             transitionView.addSubview(viewOnTopOfStack)
+            presentedViewController?.viewDidAppear(animated)
         }
     }
 

--- a/Sources/UIPanGestureRecognizer.swift
+++ b/Sources/UIPanGestureRecognizer.swift
@@ -6,13 +6,11 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import Foundation
-
 open class UIPanGestureRecognizer: UIGestureRecognizer {
     private var initialTouchPoint: CGPoint?
 
-    private var previousTouchesMovedTimestamp: TimeInterval?
-    private var touchesMovedTimestamp: TimeInterval?
+    private var previousTouchesMovedTimestamp: Double?
+    private var touchesMovedTimestamp: Double?
 
     private let minimumTranslationThreshold: CGFloat = 5
 
@@ -40,7 +38,7 @@ open class UIPanGestureRecognizer: UIGestureRecognizer {
 
     // The velocity of the pan gesture, which is expressed in points per second.
     // The velocity is broken into horizontal and vertical components.
-    func velocity(in view: UIView?, timeDiffSeconds: TimeInterval) -> CGPoint {
+    func velocity(in view: UIView?, timeDiffSeconds: Double) -> CGPoint {
         guard
             let curPos = trackedTouch?.location(in: view),
             let prevPos = trackedTouch?.previousLocation(in: view),

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -8,7 +8,6 @@
 
 import SDL
 import SDL_gpu
-import func Foundation.round
 
 extension UIScreen {
     func render(window: UIWindow?, atTime frameTimer: Timer) {
@@ -143,10 +142,10 @@ extension UIScreen {
 private extension CGRect {
     func gpuRect(scale: CGFloat) -> GPU_Rect {
         return GPU_Rect(
-            x: Float(round(self.origin.x * scale) / scale),
-            y: Float(round(self.origin.y * scale) / scale),
-            w: Float(round(self.size.width * scale) / scale),
-            h: Float(round(self.size.height * scale) / scale)
+            x: Float((self.origin.x * scale).rounded() / scale),
+            y: Float((self.origin.y * scale).rounded() / scale),
+            w: Float((self.size.width * scale).rounded() / scale),
+            h: Float((self.size.height * scale).rounded() / scale)
         )
     }
 }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -8,7 +8,6 @@
 
 import SDL
 import SDL_gpu
-import func Foundation.round
 
 extension SDLWindowFlags: OptionSet {}
 

--- a/Sources/UIScrollView+velocity.swift
+++ b/Sources/UIScrollView+velocity.swift
@@ -6,11 +6,9 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import Foundation
-
 private extension CGPoint {
     var magnitude: CGFloat {
-        return sqrt(x * x + y * y)
+        return (x * x + y * y).squareRoot()
     }
 }
 
@@ -20,8 +18,8 @@ extension UIScrollView {
         // Otherwise we could animate after scrolling quickly, pausing for a few seconds, then letting go
         let velocityIsLargeEnoughToDecelerate = (self.panGestureRecognizer.velocity(in: self).magnitude > 10)
 
-        let dampingFactor: CGFloat = 0.5 // hand-tuned
-        let nonBoundsCheckedScrollAnimationDistance = self.weightedAverageVelocity * dampingFactor // hand-tuned
+        let dampingFactor = 0.5 // hand-tuned
+        let nonBoundsCheckedScrollAnimationDistance = self.weightedAverageVelocity * CGFloat(dampingFactor) // hand-tuned
         let targetOffset = getBoundsCheckedContentOffset(contentOffset - nonBoundsCheckedScrollAnimationDistance)
         let distanceToBoundsCheckedTarget = contentOffset - targetOffset
 
@@ -36,10 +34,10 @@ extension UIScrollView {
         let animationTimeConstant = 0.325 * dampingFactor
 
         // This calculation is a weird approximation but it's close enough for now...
-        let animationTime = log(distanceToBoundsCheckedTarget.magnitude) * animationTimeConstant
+        let animationTime = log(Double(distanceToBoundsCheckedTarget.magnitude)) * animationTimeConstant
 
         UIView.animate(
-            withDuration: Double(animationTime),
+            withDuration: animationTime,
             options: [.beginFromCurrentState, .customEaseOut, .allowUserInteraction],
             animations: {
                 self.isDecelerating = true

--- a/Sources/UIScrollView.swift
+++ b/Sources/UIScrollView.swift
@@ -149,7 +149,7 @@ open class UIScrollView: UIView {
     }
 }
 
-public protocol UIScrollViewDelegate: class {
+public protocol UIScrollViewDelegate: AnyObject {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView)
     func scrollViewDidScroll(_ scrollView: UIScrollView)
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate: Bool)

--- a/Sources/UITouch.swift
+++ b/Sources/UITouch.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-import struct Foundation.TimeInterval
-
 public class UITouch {
     public init() {
         absoluteLocation = .zero
@@ -16,7 +14,7 @@ public class UITouch {
         touchId = 0
     }
 
-    internal init(touchId: Int, at point: CGPoint, timestamp: TimeInterval) {
+    internal init(touchId: Int, at point: CGPoint, timestamp: Double) {
         absoluteLocation = point
         previousAbsoluteLocation = point
         self.touchId = touchId
@@ -29,7 +27,7 @@ public class UITouch {
     public weak var window: UIWindow?
 
     public var phase: UITouchPhase = .began
-    public var timestamp: TimeInterval
+    public var timestamp: Double
 
     private var absoluteLocation: CGPoint
     private var previousAbsoluteLocation: CGPoint

--- a/UIKitTests/Gestures/UIPanGestureRecognizerTests.swift
+++ b/UIKitTests/Gestures/UIPanGestureRecognizerTests.swift
@@ -8,9 +8,6 @@
 
 import XCTest
 @testable import UIKit
-import Foundation
-
-
 
 fileprivate class TestPanGestureRecognizer: UIPanGestureRecognizer {
     let stateCancelledExpectation: XCTestExpectation?

--- a/UIKitTests/TestSetup.swift
+++ b/UIKitTests/TestSetup.swift
@@ -9,7 +9,6 @@
 #if os(iOS)
     import UIKit
 #else
-    import Foundation
     @_exported @testable import UIKit
     typealias Button = UIKit.Button
 #endif

--- a/docs/PREPARE_IOS_PROJECT.md
+++ b/docs/PREPARE_IOS_PROJECT.md
@@ -33,7 +33,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
 // main.swift
 
 import UIKit
-import Foundation
+import func Foundation.NSStringFromClass
 
 _ = UIApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, NSStringFromClass(AppDelegate.self))
 ```

--- a/samples/getting-started/DemoApp/AppDelegate.swift
+++ b/samples/getting-started/DemoApp/AppDelegate.swift
@@ -25,4 +25,3 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/samples/getting-started/DemoApp/main.swift
+++ b/samples/getting-started/DemoApp/main.swift
@@ -7,6 +7,6 @@
 //
 
 import UIKit
-import Foundation
+import func Foundation.NSStringFromClass
 
 _ = UIApplicationMain(CommandLine.argc, CommandLine.unsafeArgv, nil, NSStringFromClass(AppDelegate.self))


### PR DESCRIPTION
**Type of change:** DX

## Motivation (current vs expected behavior)

`Foundation` is huge in file size and complexity. It is difficult to build, tedious to update, and relying on it is blocking us from moving to new platforms (like the browser). As an open source project swift-corelibs-foundation has not gained a huge amount of traction and appears to be only implementing the bare minimum. In general, it seems like the Swift community is looking to replace it with lighter more specific modules. We would also do better to remove it and implement what we need from it in other ways wherever possible.

This PR makes it clear that we are really only relying on a few key parts of `Foundation` in UIKit-Cross-Platform:

- `URL` (in `AVURLAsset`, which can be split out and implemented differently)
- `Data`
- `NSAttributedString` (which also requires `NSRange` for our purposes, but can probably be removed entirely)
- `Notification(Center)`
- `Date` (only to get the current timestamp – can be implemented differently)

Some of these dependencies will be easier to to remove than others, and that work should happen in a separate PR. For now, we just want to make explicit what we are _actually_ using and remove some trivial dependencies directly.

## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] The commit messages are clean and understandable
