### PR TITLE
fix touch handling (pragmatic approach)

### DIFF
--- a/Sources/UIGestureRecognizer.swift
+++ b/Sources/UIGestureRecognizer.swift
@@ -39,7 +39,6 @@ open class UIGestureRecognizer {
                 state = .possible
             case .changed:
                 cancelOtherGestureRecognizersThatShouldNotRecognizeSimultaneously()
-                cancelTouchesInViewIfApplicable()
             default: break
             }
         }
@@ -88,12 +87,6 @@ private extension UIGestureRecognizer {
             }
 
             $0.touchesCancelled([touch], with: UIEvent())
-        }
-    }
-
-    private func cancelTouchesInViewIfApplicable() {
-        if self.cancelsTouchesInView {
-            trackedTouch?.hasBeenCancelledByAGestureRecognizer = true
         }
     }
 }

--- a/Sources/UITouch.swift
+++ b/Sources/UITouch.swift
@@ -53,8 +53,6 @@ public class UITouch {
             action(recognizer)
         }
     }
-
-    internal var hasBeenCancelledByAGestureRecognizer = false
 }
 
 extension UITouch: Hashable {

--- a/Sources/UIWindow.swift
+++ b/Sources/UIWindow.swift
@@ -57,6 +57,12 @@ public class UIWindow: UIView {
     }
 }
 
+private extension UITouch {
+    var hasBeenCancelledByAGestureRecognizer: Bool {
+        return gestureRecognizers.contains(where: { ($0.state == .changed) && $0.cancelsTouchesInView })
+    }
+}
+
 private extension UIView {
     func getRecognizerHierachy() -> [UIGestureRecognizer] {
         var recognizerHierachy: [UIGestureRecognizer] = []

--- a/UIKitTests/Gestures/TouchHandlingTests.swift
+++ b/UIKitTests/Gestures/TouchHandlingTests.swift
@@ -48,7 +48,6 @@ class TouchHandlingTests: XCTestCase {
         handleTouchUp(CGPoint(x: 15, y: 10))
 
         XCTAssertFalse(view.touchesMovedWasCalled)
-        XCTAssertFalse(view.touchesEndedWasCalled)
     }
 
     func testDoesNotCancelTouchesInView() {


### PR DESCRIPTION
This reverts commit 9a698b9914e62e4623704ee0fcefb14602b88e9c.

**Type of change:** fix broken loop handles

## Motivation (current vs expected behavior)
Reverting 9a698b9914e62e4623704ee0fcefb14602b88e9c leads to the exact same behaviour as we have on the latest commit of the `fix-touch` branch.

This commit introduces the behaviour that touchesEnded gets (maybe correctly?) cancelled, but touchesBegan does not. Thats why in our player we see that the all controls get hidden when dragging a loop handle, but they never come back on touchesEnded.

https://record.wtf/play?id=1638181427736_46106

**reproduce:**
- opens song
- open loop
- drag any of the handles to adjust the loop


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
