### PR TITLE
disable heap pointer tagging in example app

### DIFF
--- a/samples/getting-started/android/app/src/main/AndroidManifest.xml
+++ b/samples/getting-started/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,13 @@
         android:supportsRtl="true"
         >
 
+        <!--
+        Setting allowNativeHeapPointerTagging=false below prevents crashes in Swift,
+        but it will stop working in future Android versions. Hopefully Swift Android will support
+        this by then: https://source.android.com/devices/tech/debug/tagged-pointers
+        -->
         <activity
+            android:allowNativeHeapPointerTagging="false"
             android:name="com.example.MainActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
Disable heap pointer tagging to avoid potential crashes in Swift.
https://source.android.com/devices/tech/debug/tagged-pointers


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
