### PR TITLE
Implement UIAlertControllerStyle.alert

### DIFF
--- a/Sources/FontRenderer+singleLineSize.swift
+++ b/Sources/FontRenderer+singleLineSize.swift
@@ -123,7 +123,8 @@ extension FontRenderer {
             let glyph = self.rawPointer.pointee.current.pointee
 
             let spaceCharacterCode = 32
-            if characterCode != spaceCharacterCode, glyph.maxx - glyph.minx <= 0 {
+            let newLineCharacterCode = 10
+            if characterCode != spaceCharacterCode, characterCode != newLineCharacterCode, glyph.maxx - glyph.minx <= 0 {
                 assertionFailure("Glyph \(characterCode) ('\(Character(UnicodeScalar(characterCode)!))') has no width")
                 return nil
             }

--- a/Sources/UIAlertController.swift
+++ b/Sources/UIAlertController.swift
@@ -23,7 +23,6 @@ public class UIAlertController: UIViewController {
 
     public init(title: String?, message: String?, preferredStyle: UIAlertControllerStyle) {
         self.message = message
-        assert(message == nil, "We haven't implemented `message` yet")
         self.preferredStyle = preferredStyle
         super.init(nibName: nil, bundle: nil)
         self.title = title

--- a/Sources/UIAlertController.swift
+++ b/Sources/UIAlertController.swift
@@ -10,7 +10,6 @@ import func Foundation.round
 
 public enum UIAlertControllerStyle {
     case actionSheet
-    case popover
     case alert
 }
 

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -40,6 +40,8 @@ class UIAlertControllerView: UIView {
         self.style = style
         header.text = title
         header.font = UIFont.boldSystemFont(ofSize: 20)
+        header.numberOfLines = 0
+        header.layer.contentsGravity = .top
 
         if let message = message {
             text = UILabel(frame: .zero)
@@ -72,8 +74,6 @@ class UIAlertControllerView: UIView {
         backgroundColor = .white
         layer.cornerRadius = 3
 
-        header.numberOfLines = 0
-        header.layer.contentsGravity = .top
         addSubview(header)
         text.map { addSubview($0) }
         buttons.forEach { addSubview($0) }
@@ -93,16 +93,12 @@ class UIAlertControllerView: UIView {
         header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
         header.bounds.width = subviewWidth
         header.sizeToFit()
+        header.textAlignment = .left // sizeToFit() seems to change textAlignment
 
-        // XXX: sizeToFit() seems to change the alignment, so we're explicitly reassigning it here
-        header.textAlignment = .left
-
-        if let text = text {
-            text.frame.origin.x = horizontalPadding
-            text.frame.width = subviewWidth 
-            text.sizeToFit()
-            text.frame.minY = header.frame.maxY + verticalPadding
-        }
+        text?.frame.origin.x = horizontalPadding
+        text?.frame.width = subviewWidth
+        text?.sizeToFit()
+        text?.frame.minY = header.frame.maxY + verticalPadding
 
         if style == .alert {
             let totalButtonsWidth = buttons.reduce(0, { $0 + $1.frame.width }) + horizontalGap * CGFloat(buttons.count - 1)

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -82,6 +82,8 @@ class UIAlertControllerView: UIView {
             }
             return min(maxWidth, max(largestSubviewWidth, minWidth))
         }()
+        
+        subviews.forEach { $0.clipsToBounds = true }
     }
 
     override func layoutSubviews() {
@@ -134,7 +136,6 @@ class UIAlertControllerView: UIView {
     private func layoutButtonsHorizontally() {
         buttons.enumerated().forEach({ index, button in
             button.sizeToFit()
-            button.clipsToBounds = true
             button.frame.width = max(button.frame.width, 75)
             button.contentHorizontalAlignment = .center
             button.frame.minY = CGFloat(text?.frame.maxY ?? header.frame.maxY) + verticalPadding

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -39,14 +39,13 @@ class UIAlertControllerView: UIView {
     {
         self.style = style
         header.text = title
-        header.font = UIFont.systemFont(ofSize: 20)
+        header.font = UIFont.boldSystemFont(ofSize: 20)
 
         if let message = message {
             text = UILabel(frame: .zero)
             text?.numberOfLines = 0
             text?.text = message
-            text?.font = UIFont.systemFont(ofSize: 16, weight: .light)
-            text?.textColor = UIColor(hex: 0x3C3C43)
+            text?.font = UIFont.systemFont(ofSize: 16)
         } else {
             text = nil
         }
@@ -56,7 +55,7 @@ class UIAlertControllerView: UIView {
         buttons = actions.map { action in
             let button = UIAlertControllerButton(frame: .zero)
             button.setTitle(action.title, for: .normal)
-            button.setTitleColor(UIColor(hex: 0x5856D6), for: .normal)
+            button.setTitleColor(UIColor(hex: 0x757575), for: .normal) // color from react-native settings menu
             button.setTitleColor(.black, for: .highlighted)
 
             button.onPress = { [weak self] in

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -108,9 +108,7 @@ class UIAlertControllerView: UIView {
     }
 
     private func layoutButtonsVertically() {
-        buttons.enumerated().forEach({ (arg) in
-            let (index, button) = arg
-
+        buttons.enumerated().forEach({ index, button in
             let fullButtonWidth = subviewWidth + horizontalPadding * 2
 
             switch style {
@@ -123,7 +121,7 @@ class UIAlertControllerView: UIView {
             button.frame.size.width = fullButtonWidth
             button.frame.size.height += verticalPadding
 
-            if button == buttons.first {
+            if index == 0 {
                 button.frame.minY = CGFloat(text?.frame.maxY ?? header.frame.maxY) + verticalPadding
             } else {
                 let previousElement = buttons[index - 1]
@@ -134,8 +132,7 @@ class UIAlertControllerView: UIView {
     }
 
     private func layoutButtonsHorizontally() {
-        buttons.enumerated().forEach({ (arg) in
-            let (index, button) = arg
+        buttons.enumerated().forEach({ index, button in
             button.sizeToFit()
             button.clipsToBounds = true
             button.frame.width = max(button.frame.width, 75)

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -108,7 +108,7 @@ class UIAlertControllerView: UIView {
     }
 
     private func layoutButtonsVertically() {
-            let fullButtonWidth = subviewWidth + horizontalPadding * 2
+        let fullButtonWidth = subviewWidth + horizontalPadding * 2
         buttons.enumerated().forEach({ index, button in
             button.sizeToFit()
             switch style {
@@ -134,7 +134,7 @@ class UIAlertControllerView: UIView {
     private func layoutButtonsHorizontally() {
         buttons.enumerated().forEach({ index, button in
             button.sizeToFit()
-            button.frame.width = max(button.frame.width, 75)
+            button.frame.width += 25
             button.contentHorizontalAlignment = .center
             button.frame.minY = CGFloat(text?.frame.maxY ?? header.frame.maxY) + verticalPadding
             if button == buttons.first {

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -9,10 +9,11 @@
 private let verticalPadding: CGFloat = 18
 private let horizontalPadding: CGFloat = 24
 private let minWidth: CGFloat = 300
+private let horizontalGap: CGFloat = 16
 
 class UIAlertControllerView: UIView {
     let header = UILabel(frame: .zero)
-    let text: UITextView?
+    let text: UILabel?
     var buttons: [UIAlertControllerButton] = []
     let style: UIAlertControllerStyle
 
@@ -27,9 +28,10 @@ class UIAlertControllerView: UIView {
         header.font = UIFont.boldSystemFont(ofSize: 20)
 
         if let message = message {
-            text = UITextView(frame: .zero)
+            text = UILabel(frame: .zero)
+            text?.numberOfLines = 0
             text?.text = message
-            text?.font = UIFont.systemFont(ofSize: 14)
+            text?.font = UIFont.systemFont(ofSize: 16)
         } else {
             text = nil
         }
@@ -55,7 +57,7 @@ class UIAlertControllerView: UIView {
         backgroundColor = .white
         layer.cornerRadius = 3
 
-        header.sizeToFit()
+        header.numberOfLines = 0
         header.layer.contentsGravity = .top
         addSubview(header)
         text.map { addSubview($0) }
@@ -64,71 +66,101 @@ class UIAlertControllerView: UIView {
     }
 
     override func layoutSubviews() {
-        switch style {
-        case .actionSheet: layoutAsActionSheet()
-        case .alert: layoutAsAlert()
+        subviews.forEach { $0.sizeToFit() }
+        let preferredWidth = getPreferredWidth()
+
+        header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
+        header.bounds.width = preferredWidth
+        header.sizeToFit()
+
+        // XXX: sizeToFit() seems to change the alignment, so we're explicitly reassigning it here
+        header.textAlignment = .left
+
+        if let text = text {
+            text.frame.origin.x = horizontalPadding
+            text.frame.width = preferredWidth 
+            text.sizeToFit()
+            text.frame.minY = header.frame.maxY + verticalPadding
         }
+
+        if style == .alert {
+            let totalButtonsWidth = buttons.reduce(0, { $0 + $1.frame.width }) + horizontalGap * CGFloat(buttons.count - 1)
+            if totalButtonsWidth < preferredWidth {
+                return layoutButtonsHorizontally()
+            }
+        }
+        return layoutButtonsVertically(preferredWidth: preferredWidth)
+
     }
 
-    private func layoutAsActionSheet() {
-        header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
+    private func layoutButtonsVertically(preferredWidth: CGFloat) {
         buttons.enumerated().forEach({ (arg) in
             let (index, button) = arg
-            let previousElement = (index > 0) ? buttons[index - 1] : header
-            button.sizeToFit()
-            button.contentHorizontalAlignment = .left
+
+            let fullButtonWidth = preferredWidth + horizontalPadding * 2
+
+            switch style {
+            case .actionSheet:
+                button.titleLabelOriginX = horizontalPadding
+            case .alert:
+                button.titleLabelOriginX = fullButtonWidth - horizontalPadding - button.bounds.width
+            }
+
+            button.frame.size.width = fullButtonWidth
             button.frame.size.height += verticalPadding
-            button.frame.size.width = max(bounds.size.width, button.frame.size.width)
-            button.frame.origin.y = (previousElement == header)
-                ? previousElement.frame.maxY + verticalPadding
-                : previousElement.frame.maxY
-            button.titleLabelOriginX = horizontalPadding
+
+            if button == buttons.first {
+                button.frame.minY = CGFloat(text?.frame.maxY ?? header.frame.maxY) + verticalPadding
+            } else {
+                let previousElement = buttons[index - 1]
+                button.frame.origin.y = previousElement.frame.maxY
+            }
+
         })
     }
 
-    private func layoutAsAlert() {
-        guard let text = text else {
-            return
-        }
-        header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
-        text.frame.origin.x = horizontalPadding
-        text.frame.width = UIScreen.main.bounds.width * 0.5
-        text.sizeToFit()
-        text.frame.minY = header.frame.maxY + verticalPadding
+    private func layoutButtonsHorizontally() {
         buttons.enumerated().forEach({ (arg) in
             let (index, button) = arg
             button.sizeToFit()
+            button.clipsToBounds = true
             button.frame.width = max(button.frame.width, 75)
             button.contentHorizontalAlignment = .center
-            button.frame.minY = text.frame.maxY + verticalPadding
+            button.frame.minY = CGFloat(text?.frame.maxY ?? header.frame.maxY) + verticalPadding
             if button == buttons.first {
-                button.frame.origin.x = bounds.maxX - button.frame.width - verticalPadding
+                button.frame.origin.x = bounds.maxX - button.frame.width - horizontalGap
             } else {
                 let previousElement = buttons[index - 1]
-                button.frame.origin.x = previousElement.frame.minX - button.frame.width - verticalPadding
+                button.frame.origin.x = previousElement.frame.minX - button.frame.width - horizontalGap
             }
         })
     }
 
+    private func getPreferredWidth() -> CGFloat {
+        let largestSubviewWidth = getWidthOfLargestSubview()
+        let maxWidth = getMaxAlertViewWidth() - horizontalPadding * 2
+        let preferredWidth = max(largestSubviewWidth, minWidth - horizontalPadding * 2)
+        return min(maxWidth, preferredWidth)
+    }
+
+    private func getMaxAlertViewWidth() -> CGFloat {
+        if UIScreen.main.isPortrait {
+            return UIScreen.main.bounds.width - 2 * horizontalPadding
+        } else {
+            return max(minWidth, min(UIScreen.main.bounds.width / 2, 500))
+        }
+    }
+
+    private func getWidthOfLargestSubview() -> CGFloat {
+        return subviews.map { $0.frame.width }.max()!
+    }
+
     override func sizeThatFits(_ size: CGSize) -> CGSize {
         layoutIfNeeded()
-        
-        let width: CGFloat
-        let height: CGFloat
-        
-        switch style {
-        case .actionSheet:
-            width = buttons.map { $0.frame.width }.max()!
-            height = buttons.last?.frame.maxY ?? header.frame.height
-        case .alert:
-            let buttonsWidth = buttons.reduce(0, { $0 + $1.frame.width + verticalPadding })
-            width = ([header.frame.width, text?.frame.width ?? 0, buttonsWidth]).max()!
-            height = buttons.first?.frame.maxY ?? text?.frame.height ?? 0
-        }
-        
+
         return CGSize(
-            width: max(minWidth, width) + horizontalPadding,
-            height: height + verticalPadding
+            width: header.bounds.width + horizontalPadding * 2,
+            height: CGFloat(buttons.last?.frame.maxY ?? 0) + verticalPadding
         )
     }
 }
@@ -148,5 +180,12 @@ class UIAlertControllerButton: Button {
         if let titleLabelOriginX = titleLabelOriginX {
             titleLabel?.frame.origin.x = titleLabelOriginX
         }
+    }
+}
+
+private extension UIScreen {
+
+    var isPortrait: Bool {
+        return self.bounds.width < self.bounds.height
     }
 }

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -12,7 +12,7 @@ private let minWidth: CGFloat = 300
 
 class UIAlertControllerView: UIView {
     let header = UILabel(frame: .zero)
-    let text = UITextView(frame: .zero)
+    let text: UITextView?
     var buttons: [UIAlertControllerButton] = []
     let style: UIAlertControllerStyle
 
@@ -26,8 +26,13 @@ class UIAlertControllerView: UIView {
         header.text = title
         header.font = UIFont.boldSystemFont(ofSize: 20)
 
-        text.text = message
-        text.font = UIFont.systemFont(ofSize: 14)
+        if let message = message {
+            text = UITextView(frame: .zero)
+            text?.text = message
+            text?.font = UIFont.systemFont(ofSize: 14)
+        } else {
+            text = nil
+        }
 
         super.init(frame: .zero)
 
@@ -53,7 +58,7 @@ class UIAlertControllerView: UIView {
         header.sizeToFit()
         header.layer.contentsGravity = .top
         addSubview(header)
-        addSubview(text)
+        text.map { addSubview($0) }
 
         buttons.forEach{ addSubview($0) }
     }
@@ -82,6 +87,9 @@ class UIAlertControllerView: UIView {
     }
 
     private func layoutAsAlert() {
+        guard let text = text else {
+            return
+        }
         header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
         text.frame.origin.x = horizontalPadding
         text.frame.width = UIScreen.main.bounds.width * 0.5
@@ -97,7 +105,7 @@ class UIAlertControllerView: UIView {
                 button.frame.origin.x = bounds.maxX - button.frame.width - verticalPadding
             } else {
                 let previousElement = buttons[index - 1]
-                button.frame.origin.x = previousElement.frame.minX - button.frame.width
+                button.frame.origin.x = previousElement.frame.minX - button.frame.width - verticalPadding
             }
         })
     }
@@ -110,12 +118,12 @@ class UIAlertControllerView: UIView {
         
         switch style {
         case .actionSheet:
-            width = ([text] + buttons).map { $0.frame.width }.max()!
+            width = buttons.map { $0.frame.width }.max()!
             height = buttons.last?.frame.maxY ?? header.frame.height
         case .alert:
-            let buttonsWidth = buttons.reduce(0, { $0 + $1.frame.width })
-            width = ([header.frame.width, text.frame.width, buttonsWidth]).max()!
-            height = buttons.first?.frame.maxY ?? text.frame.height
+            let buttonsWidth = buttons.reduce(0, { $0 + $1.frame.width + verticalPadding })
+            width = ([header.frame.width, text?.frame.width ?? 0, buttonsWidth]).max()!
+            height = buttons.first?.frame.maxY ?? text?.frame.height ?? 0
         }
         
         return CGSize(

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -68,6 +68,7 @@ class UIAlertControllerView: UIView {
             return button
         }
 
+        clipsToBounds = true
         backgroundColor = .white
         layer.cornerRadius = 3
 

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -89,8 +89,8 @@ class UIAlertControllerView: UIView {
     override func layoutSubviews() {
         header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
         header.bounds.width = subviewWidth
+        header.textAlignment = .left
         header.sizeToFit()
-        header.textAlignment = .left // sizeToFit() seems to change textAlignment
 
         text?.frame.origin.x = horizontalPadding
         text?.frame.width = subviewWidth
@@ -163,6 +163,7 @@ class UIAlertControllerButton: Button {
         }
     }
 
+    /// set this to force the x position of the buttons label and ignore the buttons contentHorizontalAlignment
     var titleLabelOriginX: CGFloat?
     
     override func layoutSubviews() {

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -10,26 +10,13 @@ private let verticalPadding: CGFloat = 18
 private let horizontalPadding: CGFloat = 24
 private let horizontalGap: CGFloat = 16
 
-private let minWidth: CGFloat = 300 - 2 * horizontalPadding
-
-private let maxWidth: CGFloat = {
-    var result: CGFloat = 0
-    if UIScreen.main.isPortrait {
-        result = UIScreen.main.bounds.width - 2 * horizontalPadding
-    } else {
-        result = max(minWidth, min(UIScreen.main.bounds.width / 2, 500))
-    }
-    return result - 2 * horizontalPadding
-}()
-
-
 class UIAlertControllerView: UIView {
     let header = UILabel(frame: .zero)
     let text: UILabel?
     let style: UIAlertControllerStyle
 
     var buttons: [UIAlertControllerButton] = []
-    var subviewWidth: CGFloat = minWidth
+    var subviewWidth: CGFloat = 0
 
     init(
         title: String?,
@@ -79,6 +66,15 @@ class UIAlertControllerView: UIView {
         buttons.forEach { addSubview($0) }
 
         subviewWidth = {
+            let minWidth: CGFloat = 300
+            let maxWidth: CGFloat
+            if UIScreen.main.isPortrait {
+                maxWidth = UIScreen.main.bounds.width - 4 * horizontalPadding
+            } else {
+                maxWidth = max(minWidth, UIScreen.main.bounds.width / 1.5)
+            }
+
+            subviews.forEach { $0.sizeToFit() }
             guard let largestSubviewWidth = subviews.map({ $0.frame.width }).max() else {
                 assertionFailure("no subviews exist to determine largestSubviewWidth")
                 return minWidth

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -87,8 +87,6 @@ class UIAlertControllerView: UIView {
     }
 
     override func layoutSubviews() {
-        subviews.forEach { $0.sizeToFit() }
-
         header.frame.origin = CGPoint(x: horizontalPadding, y: verticalPadding)
         header.bounds.width = subviewWidth
         header.sizeToFit()
@@ -110,9 +108,9 @@ class UIAlertControllerView: UIView {
     }
 
     private func layoutButtonsVertically() {
-        buttons.enumerated().forEach({ index, button in
             let fullButtonWidth = subviewWidth + horizontalPadding * 2
-
+        buttons.enumerated().forEach({ index, button in
+            button.sizeToFit()
             switch style {
             case .actionSheet:
                 button.titleLabelOriginX = horizontalPadding

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -67,11 +67,12 @@ class UIAlertControllerView: UIView {
 
         subviewWidth = {
             let minWidth: CGFloat = 300
+            let maxReadableWidth: CGFloat = 540
             let maxWidth: CGFloat
             if UIScreen.main.isPortrait {
-                maxWidth = UIScreen.main.bounds.width - 4 * horizontalPadding
+                maxWidth = min(UIScreen.main.bounds.width - 4 * horizontalPadding, maxReadableWidth)
             } else {
-                maxWidth = max(minWidth, UIScreen.main.bounds.width / 1.5)
+                maxWidth = min(max(minWidth, UIScreen.main.bounds.width / 1.5), maxReadableWidth)
             }
 
             subviews.forEach { $0.sizeToFit() }

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -39,13 +39,14 @@ class UIAlertControllerView: UIView {
     {
         self.style = style
         header.text = title
-        header.font = UIFont.boldSystemFont(ofSize: 20)
+        header.font = UIFont.systemFont(ofSize: 20)
 
         if let message = message {
             text = UILabel(frame: .zero)
             text?.numberOfLines = 0
             text?.text = message
-            text?.font = UIFont.systemFont(ofSize: 16)
+            text?.font = UIFont.systemFont(ofSize: 16, weight: .light)
+            text?.textColor = UIColor(hex: 0x3C3C43)
         } else {
             text = nil
         }
@@ -55,7 +56,7 @@ class UIAlertControllerView: UIView {
         buttons = actions.map { action in
             let button = UIAlertControllerButton(frame: .zero)
             button.setTitle(action.title, for: .normal)
-            button.setTitleColor(UIColor(hex: 0x757575), for: .normal) // color from react-native settings menu
+            button.setTitleColor(UIColor(hex: 0x5856D6), for: .normal)
             button.setTitleColor(.black, for: .highlighted)
 
             button.onPress = { [weak self] in

--- a/Sources/UIAlertControllerView.swift
+++ b/Sources/UIAlertControllerView.swift
@@ -66,8 +66,13 @@ class UIAlertControllerView: UIView {
         buttons.forEach { addSubview($0) }
 
         subviewWidth = {
+            // arbitrary mininum width of the alert view
             let minWidth: CGFloat = 300
+            
+            // assuming a text font size of 16 we want to limit the width
+            // of the alert view so that the text stays well readable
             let maxReadableWidth: CGFloat = 540
+            
             let maxWidth: CGFloat
             if UIScreen.main.isPortrait {
                 maxWidth = min(UIScreen.main.bounds.width - 4 * horizontalPadding, maxReadableWidth)
@@ -163,7 +168,8 @@ class UIAlertControllerButton: Button {
         }
     }
 
-    /// set this to force the x position of the buttons label and ignore the buttons contentHorizontalAlignment
+    /// Set this to force the x position of the buttons label and ignore the buttons contentHorizontalAlignment.
+    /// This is needed to give the vertically layed out buttons the full width of its container while being able to indent its title.
     var titleLabelOriginX: CGFloat?
     
     override func layoutSubviews() {

--- a/Sources/UIViewController.swift
+++ b/Sources/UIViewController.swift
@@ -24,11 +24,7 @@ open class UIViewController: UIResponder {
     open internal(set) weak var presentingViewController: UIViewController?
 
     // The `presentedViewController` is owned by its parent, but not the other way around:
-    open internal(set) var presentedViewController: UIViewController? {
-        didSet {
-            print("presentedViewController was set to \(presentedViewController)")
-        }
-    }
+    open internal(set) var presentedViewController: UIViewController?
 
     public init(nibName: String?, bundle: Bundle?) {
         super.init()

--- a/Sources/UIViewController.swift
+++ b/Sources/UIViewController.swift
@@ -24,7 +24,11 @@ open class UIViewController: UIResponder {
     open internal(set) weak var presentingViewController: UIViewController?
 
     // The `presentedViewController` is owned by its parent, but not the other way around:
-    open internal(set) var presentedViewController: UIViewController?
+    open internal(set) var presentedViewController: UIViewController? {
+        didSet {
+            print("presentedViewController was set to \(presentedViewController)")
+        }
+    }
 
     public init(nibName: String?, bundle: Bundle?) {
         super.init()

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -11,6 +11,11 @@ import UIKit
 class ViewController: UIViewController {
 
     let label = UILabel()
+    let buttonForAlert = Button()
+    let buttonForAction = Button()
+    
+    let alertController = UIAlertController(title: "Alert Message", message: alertMessageShortest, preferredStyle: .alert)
+    let actionsController = UIAlertController(title: "Actions", message: nil, preferredStyle: .actionSheet)
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -19,8 +24,41 @@ class ViewController: UIViewController {
         label.font = .systemFont(ofSize: 30)
         label.sizeToFit()
         label.center = view.center
+        
+        buttonForAlert.setTitle("Show Alert", for: .normal)
+        buttonForAlert.titleLabel?.font = .systemFont(ofSize: 20)
+        buttonForAlert.sizeToFit()
+        buttonForAlert.frame.midX = view.frame.midX
+        buttonForAlert.frame.minY = label.frame.maxY + 10
+        buttonForAlert.onPress = {
+            self.present(self.alertController, animated: true, completion: {})
+        }
+        
+        buttonForAction.setTitle("Show Actions", for: .normal)
+        buttonForAction.titleLabel?.font = .systemFont(ofSize: 20)
+        buttonForAction.sizeToFit()
+        buttonForAction.frame.midX = view.frame.midX
+        buttonForAction.frame.minY = buttonForAlert.frame.maxY
+        buttonForAction.onPress = {
+            self.present(self.actionsController, animated: true, completion: nil)
+        }
+        
+        actionsController.addAction(UIAlertAction(title: "First Action", style: .default, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Second Action", style: .cancel, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Third Action", style: .destructive, handler: nil))
+        
+        alertController.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
 
         view.backgroundColor = UIColor(red: 0 / 255, green: 206 / 255, blue: 201 / 255, alpha: 1)
         view.addSubview(label)
+        view.addSubview(buttonForAlert)
+        view.addSubview(buttonForAction)
     }
 }
+
+private let alertMessage = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum."
+
+private let alertMessageShort = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore."
+
+private let alertMessageShortest = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr."

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -40,8 +40,8 @@ class ViewController: UIViewController {
         buttonForActions.center.y = buttonForAlert.frame.maxY + 10
         
         #if os(iOS)
-        buttonForAlert.addTarget(self, action: #selector(objc_presentAlertController), for: .touchDown)
-        buttonForActions.addTarget(self, action: #selector(objc_presentActionsController), for: .touchDown)
+        buttonForAlert.addTarget(self, action: #selector(objc_presentAlertController), for: .touchUpInside)
+        buttonForActions.addTarget(self, action: #selector(objc_presentActionsController), for: .touchUpInside)
         #else
         buttonForAlert.onPress = { self.presentAlertController() }
         buttonForActions.onPress = { self.presentActionsController() }

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -8,13 +8,17 @@
 
 import UIKit
 
+#if os(iOS)
+typealias Button = UIButton
+#endif
+
 class ViewController: UIViewController {
 
     let label = UILabel()
     let buttonForAlert = Button()
-    let buttonForAction = Button()
+    let buttonForActions = Button()
     
-    let alertController = UIAlertController(title: "Alert Message", message: alertMessageShortest, preferredStyle: .alert)
+    let alertController = UIAlertController(title: "Alert Message", message: alertMessage, preferredStyle: .alert)
     let actionsController = UIAlertController(title: "Actions", message: nil, preferredStyle: .actionSheet)
 
     override func viewWillAppear(_ animated: Bool) {
@@ -28,24 +32,30 @@ class ViewController: UIViewController {
         buttonForAlert.setTitle("Show Alert", for: .normal)
         buttonForAlert.titleLabel?.font = .systemFont(ofSize: 20)
         buttonForAlert.sizeToFit()
-        buttonForAlert.frame.midX = view.frame.midX
-        buttonForAlert.frame.minY = label.frame.maxY + 10
-        buttonForAlert.onPress = {
-            self.present(self.alertController, animated: true, completion: {})
-        }
+        buttonForAlert.center.x = view.frame.midX
+        buttonForAlert.center.y = label.frame.maxY + 30
+
+        buttonForActions.setTitle("Show Actions", for: .normal)
+        buttonForActions.titleLabel?.font = .systemFont(ofSize: 20)
+        buttonForActions.sizeToFit()
+        buttonForActions.center.x = view.frame.midX
+        buttonForActions.center.y = buttonForAlert.frame.maxY + 10
         
-        buttonForAction.setTitle("Show Actions", for: .normal)
-        buttonForAction.titleLabel?.font = .systemFont(ofSize: 20)
-        buttonForAction.sizeToFit()
-        buttonForAction.frame.midX = view.frame.midX
-        buttonForAction.frame.minY = buttonForAlert.frame.maxY
-        buttonForAction.onPress = {
+        #if os(iOS)
+        buttonForAlert.addTarget(self, action: #selector(presentAlertController), for: .touchDown)
+        buttonForActions.addTarget(self, action: #selector(presentActionsController), for: .touchDown)
+        #else
+        buttonForAlert.onPress = {
+            self.present(self.alertController, animated: true, completion: nil)
+        }
+        buttonForActions.onPress = {
             self.present(self.actionsController, animated: true, completion: nil)
         }
+        #endif
         
         actionsController.addAction(UIAlertAction(title: "First Action", style: .default, handler: nil))
-        actionsController.addAction(UIAlertAction(title: "Second Action", style: .cancel, handler: nil))
-        actionsController.addAction(UIAlertAction(title: "Third Action", style: .destructive, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Second Action", style: .destructive, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Third Action", style: .cancel, handler: nil))
         
         alertController.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
         alertController.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
@@ -53,12 +63,17 @@ class ViewController: UIViewController {
         view.backgroundColor = UIColor(red: 0 / 255, green: 206 / 255, blue: 201 / 255, alpha: 1)
         view.addSubview(label)
         view.addSubview(buttonForAlert)
-        view.addSubview(buttonForAction)
+        view.addSubview(buttonForActions)
     }
+    
+    #if os(iOS)
+    @objc func presentAlertController() {
+        self.present(self.alertController, animated: true, completion: nil)
+    }
+    @objc func presentActionsController() {
+        self.present(self.actionsController, animated: true, completion: nil)
+    }
+    #endif
 }
 
 private let alertMessage = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum."
-
-private let alertMessageShort = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore."
-
-private let alertMessageShortest = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr."

--- a/samples/getting-started/DemoApp/ViewController.swift
+++ b/samples/getting-started/DemoApp/ViewController.swift
@@ -18,8 +18,6 @@ class ViewController: UIViewController {
     let buttonForAlert = Button()
     let buttonForActions = Button()
     
-    let alertController = UIAlertController(title: "Alert Message", message: alertMessage, preferredStyle: .alert)
-    let actionsController = UIAlertController(title: "Actions", message: nil, preferredStyle: .actionSheet)
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -42,36 +40,47 @@ class ViewController: UIViewController {
         buttonForActions.center.y = buttonForAlert.frame.maxY + 10
         
         #if os(iOS)
-        buttonForAlert.addTarget(self, action: #selector(presentAlertController), for: .touchDown)
-        buttonForActions.addTarget(self, action: #selector(presentActionsController), for: .touchDown)
+        buttonForAlert.addTarget(self, action: #selector(objc_presentAlertController), for: .touchDown)
+        buttonForActions.addTarget(self, action: #selector(objc_presentActionsController), for: .touchDown)
         #else
-        buttonForAlert.onPress = {
-            self.present(self.alertController, animated: true, completion: nil)
-        }
-        buttonForActions.onPress = {
-            self.present(self.actionsController, animated: true, completion: nil)
-        }
+        buttonForAlert.onPress = { self.presentAlertController() }
+        buttonForActions.onPress = { self.presentActionsController() }
         #endif
-        
-        actionsController.addAction(UIAlertAction(title: "First Action", style: .default, handler: nil))
-        actionsController.addAction(UIAlertAction(title: "Second Action", style: .destructive, handler: nil))
-        actionsController.addAction(UIAlertAction(title: "Third Action", style: .cancel, handler: nil))
-        
-        alertController.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
-        alertController.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
 
         view.backgroundColor = UIColor(red: 0 / 255, green: 206 / 255, blue: 201 / 255, alpha: 1)
         view.addSubview(label)
         view.addSubview(buttonForAlert)
         view.addSubview(buttonForActions)
     }
-    
-    #if os(iOS)
-    @objc func presentAlertController() {
-        self.present(self.alertController, animated: true, completion: nil)
+
+    func presentAlertController() {
+        let alertController = UIAlertController(title: "Alert Message", message: alertMessage, preferredStyle: .alert)
+        #if os(iOS)
+        alertController.popoverPresentationController?.sourceView = buttonForAlert
+        #endif
+        alertController.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        alertController.addAction(UIAlertAction(title: "Cancel", style: .destructive, handler: nil))
+        self.present(alertController, animated: true, completion: nil)
     }
-    @objc func presentActionsController() {
-        self.present(self.actionsController, animated: true, completion: nil)
+
+    func presentActionsController() {
+        let actionsController = UIAlertController(title: "Actions", message: nil, preferredStyle: .actionSheet)
+        #if os(iOS)
+        actionsController.popoverPresentationController?.sourceView = buttonForActions
+        #endif
+        actionsController.addAction(UIAlertAction(title: "First Action", style: .default, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Second Action", style: .destructive, handler: nil))
+        actionsController.addAction(UIAlertAction(title: "Third Action", style: .cancel, handler: nil))
+        self.present(actionsController, animated: true, completion: nil)
+    }
+
+    #if os(iOS)
+    @objc func objc_presentAlertController() {
+        presentAlertController()
+    }
+
+    @objc func objc_presentActionsController() {
+        presentActionsController()
     }
     #endif
 }


### PR DESCRIPTION
**Type of change:** feature

## Motivation (current vs expected behavior)
So far we only handled `.actionSheet` style for UIAlertControllers. This PR adds code to handle the `.alert` style.


alert style:
<img width="450" alt="Bildschirmfoto 2021-12-09 um 19 09 53" src="https://user-images.githubusercontent.com/2410252/145453042-5ed51d41-ff8f-42aa-8f18-8407b73be412.png">

actionSheet for reference:
<img width="450" alt="Bildschirmfoto 2021-12-09 um 19 09 56" src="https://user-images.githubusercontent.com/2410252/145453037-16913a8e-78bd-49d1-a20b-b76ac7d79ec4.png">

demo:
![demo](https://user-images.githubusercontent.com/2410252/145455756-91c2bd78-c445-4f87-b083-50a9f66657b2.gif)


## Please check if the PR fulfills these requirements
- [x] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [x] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [x] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
