### PR TITLE
Use setZOrderMediaOverlay instead of setZOrderOnTop

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -82,7 +82,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
         // Set up the surface
         mSurface = SurfaceView(context)
-        mSurface.setZOrderOnTop(true) // so we can cover the video (fixes Android 8 bug)
+        mSurface.setZOrderMediaOverlay(true) // so we can cover the video (fixes Android 8 bug)
 
         // Enables the alpha value for colors on the SDLSurface
         // which makes the VideoJNI SurfaceView behind it visible


### PR DESCRIPTION
**Type of change:** bug fix

## Motivation (current vs expected behavior)
Allow views from react-native to be rendered on top of UIKit Views.

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
