### PR TITLE
Downgrade ExoPlayer to v2.13.2 to match react-native-video version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.google.android.exoplayer:exoplayer:2.13.3"
+    implementation "com.google.android.exoplayer:exoplayer:2.13.2"
 }
 
 repositories {


### PR DESCRIPTION
See: https://github.com/flowkey/mobile-app/pull/2254
See https://github.com/flowkey/NativePlayer/pull/939

**Type of change:** chore

## Motivation (current vs expected behavior)
The latest `react-native-video` uses ExoPlayer `v2.13.2` - while our current `fix-touch` branch uses `v2.13.3`- it might be good to align these versions.

Note that our current production app uses `v2.11.7` so we are not really rolling back to an older version as far as users are concerned.

[Release notes for v2.13.3](https://github.com/google/ExoPlayer/releases/tag/r2.13.3)



## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
