### PR TITLE
Add AVPlayer.onVideoBuffering callback

### DIFF
--- a/Sources/AVPlayer+Android.swift
+++ b/Sources/AVPlayer+Android.swift
@@ -10,7 +10,9 @@ import JNI
 
 public class AVPlayer: JNIObject {
     public var onLoaded: ((Error?) -> Void)?
+    public var onVideoReady: (() -> Void)?
     public var onVideoEnded: (() -> Void)?
+    public var onVideoBuffering: (() -> Void)?
 
     public convenience init(playerItem: AVPlayerItem) {
         let parentView = JavaSDLView(getSDLView())
@@ -59,11 +61,18 @@ private weak var globalAVPlayer: AVPlayer?
 public func nativeOnVideoReady(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
     globalAVPlayer?.onLoaded?(nil)
     globalAVPlayer?.onLoaded = nil
+
+    globalAVPlayer?.onVideoReady?()
 }
 
 @_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoEnded")
 public func nativeOnVideoEnded(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
     globalAVPlayer?.onVideoEnded?()
+}
+
+@_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoBuffering")
+public func nativeOnVideoBuffering(env: UnsafeMutablePointer<JNIEnv>, cls: JavaObject) {
+    globalAVPlayer?.onVideoBuffering?()
 }
 
 @_cdecl("Java_org_uikit_AVPlayer_nativeOnVideoSourceError")

--- a/src/main/java/org/uikit/VideoJNI.kt
+++ b/src/main/java/org/uikit/VideoJNI.kt
@@ -48,6 +48,7 @@ class AVPlayer(parent: SDLActivity, asset: AVURLAsset) {
 
     external fun nativeOnVideoReady()
     external fun nativeOnVideoEnded()
+    external fun nativeOnVideoBuffering()
     external fun nativeOnVideoSourceError()
 
     init {
@@ -65,12 +66,11 @@ class AVPlayer(parent: SDLActivity, asset: AVURLAsset) {
 
         listener = object: Player.EventListener {
             override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {
-                if (playbackState == Player.STATE_READY) {
-                    nativeOnVideoReady()
-                }
-
-                if (playbackState == Player.STATE_ENDED) {
-                    nativeOnVideoEnded()
+                when (playbackState) {
+                    Player.STATE_READY -> nativeOnVideoReady()
+                    Player.STATE_ENDED -> nativeOnVideoEnded()
+                    Player.STATE_BUFFERING -> nativeOnVideoBuffering()
+                    else -> {}
                 }
             }
 


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
Provide a way to know if the video is stalled.

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
