### PR TITLE
swift 5.5.2 and safely unwrap shared Application from render

### DIFF
--- a/Sources/UIApplication.swift
+++ b/Sources/UIApplication.swift
@@ -91,8 +91,8 @@ private let maxFrameRenderTimeInSeconds = 1.0 / 60.0
 @_cdecl("Java_org_libsdl_app_SDLActivity_nativeProcessEventsAndRender")
 public func nativeProcessEventsAndRender(env: UnsafeMutablePointer<JNIEnv?>?, view: JavaObject?) {
     let frameTime = Timer()
-    UIApplication.shared.handleEventsIfNeeded()
-    UIScreen.main?.render(window: UIApplication.shared.keyWindow, atTime: frameTime)
+    UIApplication.shared?.handleEventsIfNeeded()
+    UIScreen.main?.render(window: UIApplication.shared?.keyWindow, atTime: frameTime)
     let remainingFrameTime = maxFrameRenderTimeInSeconds - frameTime.elapsedTimeInSeconds
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, max(0.001, remainingFrameTime / 2), true)
 }


### PR DESCRIPTION
**Type of change:** DX / UX

## Motivation (current vs expected behavior)
- https://github.com/flowkey/swift-android-toolchain/pull/14
- safely unwrap `UIApplication.shared`


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
