### PR TITLE
complete pending animations before UIScreen gets deinited

### DIFF
--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -106,7 +106,6 @@ public final class UIScreen {
         UIView.completePendingAnimations()
         UIView.layersWithAnimations.removeAll()
         UIView.currentAnimationPrototype = nil
-
         UIEvent.activeEvents.removeAll()
         FontRenderer.cleanupSession()
 

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -103,9 +103,11 @@ public final class UIScreen {
     }
 
     deinit {
+        UIView.completePendingAnimations()
         UIView.layersWithAnimations.removeAll()
-        UIEvent.activeEvents.removeAll()
         UIView.currentAnimationPrototype = nil
+
+        UIEvent.activeEvents.removeAll()
         FontRenderer.cleanupSession()
 
         if rawPointer == nil { return } // dummy screen or already destroyed

--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
+import class Foundation.NSDate
+
 extension UIView {
     static var layersWithAnimations = Set<CALayer>()
     static var currentAnimationPrototype: CABasicAnimationPrototype?
@@ -67,6 +69,10 @@ extension UIView {
 
     static func animateIfNeeded(at currentTime: Timer) {
         layersWithAnimations.forEach { $0.animate(at: currentTime) }
+    }
+
+    static func completePendingAnimations() {
+        layersWithAnimations.forEach { $0.animate(at: Timer(startingAt: NSDate.distantFuture.timeIntervalSince1970)) }
     }
 }
 


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Complete pending animations before UIScreen gets deinited. This corresponds to iOS behaviour.

**Expectation:**
- start animation with any duration/delay
- move app in background and foreground again
- animations are completed


## iOS behaviour

```swift
let box = UIView()
box.backgroundColor = .red
box.frame = CGRect(x: 0, y: 100, width: 200, height: 200)

UIView.animate(withDuration: 15, delay: 5, options: [], animations: {
    box.frame = CGRect(x: 300, y: 400, width: 200, height: 300)
    box.backgroundColor = .blue
}, completion: { finished in
    print("finished", finished)
})
```

https://user-images.githubusercontent.com/5617793/159062807-ed27cb31-e12a-47ea-b836-ad9551d37b01.mp4

even skips the delay:

https://user-images.githubusercontent.com/5617793/159062792-d96b89fa-3607-4379-8e14-2284148d8e09.mp4


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
