### PR TITLE
replace NSDate.distantFuture with arbitrary value

### DIFF
--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -73,6 +73,7 @@ extension UIView {
 
     static func completePendingAnimations() {
         layersWithAnimations.forEach {
+            // run pending animations which are supposed to finish within the next 60 minutes
             let oneHourInMs: Double = 60 * 60 * 1000
             $0.animate(at: Timer(startingAt: oneHourInMs))
         }

--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -73,7 +73,7 @@ extension UIView {
 
     static func completePendingAnimations() {
         layersWithAnimations.forEach {
-            let oneHourInMs = 60 * 60 * 1000
+            let oneHourInMs: Double = 60 * 60 * 1000
             $0.animate(at: Timer(startingAt: oneHourInMs))
         }
     }

--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -72,7 +72,10 @@ extension UIView {
     }
 
     static func completePendingAnimations() {
-        layersWithAnimations.forEach { $0.animate(at: Timer(startingAt: NSDate.distantFuture.timeIntervalSince1970)) }
+        layersWithAnimations.forEach {
+            let oneHourInMs = 60 * 60 * 1000
+            $0.animate(at: Timer(startingAt: oneHourInMs))
+        }
     }
 }
 


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Accessing `NSDate.distantFuture.timeIntervalSince1970` seems to crash on 32bit devices.

https://app.bugsnag.com/flowkey-gmbh/mobile-app/errors/623efdd47648f400086e64de?filters[app.release_stage]=production&filters[release.seen_in][]=2.35.3&filters[release.seen_in][]=2.35.3%20(*)&filters[event.unhandled]=true





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
