### PR TITLE
make sure Timer does not crash for huge startingTimeInMilliseconds values on 32 bit arch

### DIFF
--- a/Sources/Timer.swift
+++ b/Sources/Timer.swift
@@ -20,12 +20,8 @@ struct Timer {
 
         let seconds = (startingTimeInMilliseconds / 1000).rounded(.down)
         let milliseconds = startingTimeInMilliseconds.truncatingRemainder(dividingBy: 1000)
-        if !seconds.isZero {
-            startTime.tv_sec += type(of: startTime.tv_sec).init(seconds)
-        }
-        if !milliseconds.isZero {
-            startTime.tv_usec += type(of: startTime.tv_usec).init(milliseconds * 1000)
-        }
+        startTime.tv_sec += type(of: startTime.tv_sec).init(seconds)
+        startTime.tv_usec += type(of: startTime.tv_usec).init(milliseconds * 1000)
 
         self.startTime = startTime
     }

--- a/Sources/Timer.swift
+++ b/Sources/Timer.swift
@@ -18,13 +18,13 @@ struct Timer {
         var startTime = timeval()
         gettimeofday(&startTime, nil)
 
-        let seconds = startingTimeInMilliseconds / 1000
+        let seconds = (startingTimeInMilliseconds / 1000).rounded(.down)
         let milliseconds = startingTimeInMilliseconds.truncatingRemainder(dividingBy: 1000)
         if !seconds.isZero {
             startTime.tv_sec += type(of: startTime.tv_sec).init(seconds)
         }
         if !milliseconds.isZero {
-            startTime.tv_usec += type(of: startTime.tv_usec).init(milliseconds)
+            startTime.tv_usec += type(of: startTime.tv_usec).init(milliseconds * 1000)
         }
 
         self.startTime = startTime

--- a/Sources/Timer.swift
+++ b/Sources/Timer.swift
@@ -17,9 +17,16 @@ struct Timer {
     init(startingAt startingTimeInMilliseconds: Double = 0.0) {
         var startTime = timeval()
         gettimeofday(&startTime, nil)
-        if !startingTimeInMilliseconds.isZero {
-            startTime.tv_usec += type(of: startTime.tv_usec).init(startingTimeInMilliseconds * 1000)
+
+        let seconds = startingTimeInMilliseconds / 1000
+        let milliseconds = startingTimeInMilliseconds.truncatingRemainder(dividingBy: 1000)
+        if !seconds.isZero {
+            startTime.tv_sec += type(of: startTime.tv_sec).init(seconds)
         }
+        if !milliseconds.isZero {
+            startTime.tv_usec += type(of: startTime.tv_usec).init(milliseconds)
+        }
+
         self.startTime = startTime
     }
 

--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -73,9 +73,7 @@ extension UIView {
 
     static func completePendingAnimations() {
         layersWithAnimations.forEach {
-            // run pending animations which are supposed to finish within the next 60 minutes
-            let oneHourInMs: Double = 60 * 60 * 1000
-            $0.animate(at: Timer(startingAt: oneHourInMs))
+            $0.animate(at: Timer(startingAt: NSDate.distantFuture.timeIntervalSince1970))
         }
     }
 }

--- a/Sources/UIView+animate.swift
+++ b/Sources/UIView+animate.swift
@@ -73,7 +73,7 @@ extension UIView {
 
     static func completePendingAnimations() {
         layersWithAnimations.forEach {
-            $0.animate(at: Timer(startingAt: NSDate.distantFuture.timeIntervalSince1970))
+            $0.animate(at: Timer(startingAt: NSDate.distantFuture.timeIntervalSinceNow))
         }
     }
 }


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
- fixes [this crash](https://app.bugsnag.com/flowkey-gmbh/mobile-app/errors/623efdd47648f400086e64de?filters[app.release_stage]=production&filters[release.seen_in][]=2.35.4&filters[release.seen_in][]=2.35.4%20(*)&filters[event.unhandled]=true)
- reverts the first attempt to fix the crash https://github.com/flowkey/UIKit-cross-platform/commit/6cb855df84e9b98638321cdfe87b547b04fc4e91
- improves timer to ensure it does not crash for huge `startingTimeInMilliseconds` values on 32 bit arch



## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
