### PR TITLE
safely unwrap main screen in string.size()

### DIFF
--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -175,8 +175,8 @@ extension NSAttributedString {
 extension String {
     public func size(with font: UIFont, wrapLength: CGFloat = 0) -> CGSize {
         guard
-            let renderer = font.renderer
-            let screen = UIScreen.main.scale
+            let renderer = font.renderer,
+            let screen = UIScreen.main
         else { return .zero }
 
         let retinaResolutionSize =
@@ -184,9 +184,9 @@ extension String {
                 renderer.singleLineSize(of: self) :
                 renderer.multilineSize(
                     of: self,
-                    wrapLength: UInt(wrapLength * screen)
+                    wrapLength: UInt(wrapLength * screen.scale)
                 )
 
-        return retinaResolutionSize / screen
+        return retinaResolutionSize / screen.scale
     }
 }


### PR DESCRIPTION
**Type of change:** UX

## Motivation (current vs expected behavior)
May fix a newly introduced crash 

```
SIGTRAP Trace/breakpoint trap 
    UIKit/Sources/UIFont.swift:187 (extension in UIKit):Swift.String.size(with
    FlowkeyPlayer/Components/NoteNames.swift:73 (extension in FlowkeyPlayer):PlayerLogic.NoteName.frame.getter 
    FlowkeyPlayer/Components/NoteNames.swift:27 closure #1 (PlayerLogic.NoteName) -> UIKit.UILabel in FlowkeyPlayer.NoteNames.update(noteNames
    PlayerLogic/NoteNamesLogic.swift:24 closure #1 ((Swift.Int, Swift.String)) -> PlayerLogic.NoteName in closure #1 (PlayerLogic.PlayerState) -> () in (extension in PlayerLogic):PlayerLogic.NoteNamesComponent.connect(to
    build/arm64-v8a/<compiler-generated>:42 unknown_symbol
    build/arm64-v8a/<compiler-generated>:42 unknown_symbol
```
https://app.bugsnag.com/flowkey-gmbh/mobile-app/errors/6241c9e1e519f00009577175?filters[app.release_stage]=production&filters[release.seen_in]=2.36.0%20(2154883)&filters[event.unhandled]=true

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
