### PR TITLE
fix crash in font rendering

### DIFF
--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -33,6 +33,10 @@ open class UIFont {
     }
 
     public init?(name: String, size: CGFloat) {
+        guard UIScreen.main != nil else {
+            return nil
+        }
+
         let name = name.lowercased()
         let size = Int32(size * UIScreen.main.scale)
 

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -48,7 +48,8 @@ open class UILabel: UIView {
         layer.contentsGravity = textAlignment.contentsGravity()
     }
 
-    open var font: UIFont = .systemFont(ofSize: 16) {
+    static var defaultFont = UIFont.systemFont(ofSize: 16)
+    open var font: UIFont = UILabel.defaultFont {
         didSet { if font != oldValue { setNeedsDisplay() } }
     }
 

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -48,7 +48,7 @@ open class UILabel: UIView {
         layer.contentsGravity = textAlignment.contentsGravity()
     }
 
-    static var defaultFont = UIFont.systemFont(ofSize: 16)
+    static let defaultFont = UIFont.systemFont(ofSize: 16)
     open var font: UIFont = UILabel.defaultFont {
         didSet { if font != oldValue { setNeedsDisplay() } }
     }


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Fixes a crash which happens when initing UIFont while main screen doesn't exist.
See https://github.com/flowkey/NativePlayer/pull/981





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
