### PR TITLE
Cache screen scale to prevent crashes

### DIFF
--- a/Sources/AVPlayerLayer+Android.swift
+++ b/Sources/AVPlayerLayer+Android.swift
@@ -19,7 +19,7 @@ public class AVPlayerLayer: JNIObject {
     public var frame: CGRect {
         get { return .zero } // FIXME: This would require returning a JavaObject with the various params
         set {
-            let scaledFrame = (newValue * UIScreen.main.scale)
+            let scaledFrame = (newValue * UIScreen.lastKnownScale)
             try! call(methodName: "setFrame", arguments: [
                 JavaInt(round(scaledFrame.origin.x)),
                 JavaInt(round(scaledFrame.origin.y)),

--- a/Sources/FontRenderer+renderAttributedString.swift
+++ b/Sources/FontRenderer+renderAttributedString.swift
@@ -88,7 +88,7 @@ extension FontRenderer {
             if let attributedKerningOffset =
                 attributedString.attribute(.kern, at: index, effectiveRange: nil) as? CGFloat
             {
-                xOffset += Int32(attributedKerningOffset * UIScreen.main.scale)
+                xOffset += Int32(attributedKerningOffset * UIScreen.lastKnownScale)
             }
 
             xOffset += glyph.advance

--- a/Sources/FontRenderer+singleLineSize.swift
+++ b/Sources/FontRenderer+singleLineSize.swift
@@ -144,6 +144,6 @@ private extension NSAttributedString {
             }
         }
 
-        return width * UIScreen.main.scale
+        return width * UIScreen.lastKnownScale
     }
 }

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -251,8 +251,8 @@ public func onNativeTouch(
             timestamp: UInt32(timestampMs),
             touchId: Int64(touchDeviceID), // some arbitrary number, stays the same per device
             fingerId: Int64(pointerFingerID),
-            x: x / Float(UIScreen.main.scale),
-            y: y / Float(UIScreen.main.scale),
+            x: x / Float(UIScreen.lastKnownScale),
+            y: y / Float(UIScreen.lastKnownScale),
             dx: 0,
             dy: 0,
             pressure: pressure

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -13,7 +13,7 @@ open class UIFont {
     }
     public var pointSize: CGFloat
     public var lineHeight: CGFloat {
-        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.main.scale
+        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.lastKnownScale
     }
 
     /**
@@ -34,7 +34,7 @@ open class UIFont {
 
     public init?(name: String, size: CGFloat) {
         let name = name.lowercased()
-        let size = Int32(size * UIScreen.main.scale)
+        let size = Int32(size * UIScreen.lastKnownScale)
 
         self.fontName = name
         self.pointSize = CGFloat(size)
@@ -66,7 +66,7 @@ open class UIFont {
     }
 
     internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0) -> CGImage? {
-        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale))
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.lastKnownScale))
     }
 
     internal func render(_ attributedString: NSAttributedString?, color: UIColor, wrapLength: CGFloat = 0) -> CGImage? {
@@ -167,26 +167,23 @@ extension NSAttributedString {
     public func size(with font: UIFont, wrapLength: CGFloat = 0) -> CGSize {
         guard let renderer = font.renderer else { return .zero }
         return wrapLength == 0 ?
-            renderer.singleLineSize(of: self) / UIScreen.main.scale :
+            renderer.singleLineSize(of: self) / UIScreen.lastKnownScale :
             string.size(with: font, wrapLength: wrapLength) // fallback to String.size for multiline text
     }
 }
 
 extension String {
     public func size(with font: UIFont, wrapLength: CGFloat = 0) -> CGSize {
-        guard
-            let renderer = font.renderer,
-            let screen = UIScreen.main
-        else { return .zero }
+        guard let renderer = font.renderer else { return .zero }
 
         let retinaResolutionSize =
             (wrapLength <= 0) ? // a wrapLength of < 0 leads to a crash, so assume 0
                 renderer.singleLineSize(of: self) :
                 renderer.multilineSize(
                     of: self,
-                    wrapLength: UInt(wrapLength * screen.scale)
+                    wrapLength: UInt(wrapLength * UIScreen.lastKnownScale)
                 )
 
-        return retinaResolutionSize / screen.scale
+        return retinaResolutionSize / UIScreen.lastKnownScale
     }
 }

--- a/Sources/UIImage.swift
+++ b/Sources/UIImage.swift
@@ -29,7 +29,7 @@ public class UIImage {
         let (pathWithoutExtension, fileExtension) = name.pathAndExtension()
 
         // e.g. ["@3x", "@2x", ""]
-        let scale = Int(UIScreen.main.scale.rounded())
+        let scale = Int(UIScreen.lastKnownScale.rounded())
         let possibleScaleStrings = stride(from: scale, to: 1, by: -1)
             .map { "@\($0)x" }
             + [""] // it's possible to have no scale string (e.g. "image.png")

--- a/Sources/UIImageView.swift
+++ b/Sources/UIImageView.swift
@@ -20,7 +20,7 @@ open class UIImageView: UIView {
 
     private func updateTextureFromImage() {
         layer.contents = image?.cgImage
-        layer.contentsScale = image?.scale ?? UIScreen.main.scale
+        layer.contentsScale = image?.scale ?? UIScreen.lastKnownScale
         if let image = image {
             bounds.size = image.size
         }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -24,12 +24,15 @@ public final class UIScreen {
     internal var rawPointer: UnsafeMutablePointer<GPU_Target>!
 
     public let bounds: CGRect
-    public let scale: CGFloat
+    private(set) public var scale: CGFloat {
+        return UIScreen.lastKnownScale
+    }
 
-    private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect, scale: CGFloat) {
+    internal static var lastKnownScale: CGFloat = 1.0
+
+    private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect) {
         self.rawPointer = renderTarget
         self.bounds = bounds
-        self.scale = scale
     }
 
     convenience init() {
@@ -84,14 +87,15 @@ public final class UIScreen {
         let scale = CGFloat(gpuTarget.pointee.base_h) / CGFloat(gpuTarget.pointee.h)
         #endif
 
+        UIScreen.lastKnownScale = scale
+
         if size == .zero {
             preconditionFailure("You need window dimensions to run")
         }
 
         self.init(
             renderTarget: gpuTarget,
-            bounds: CGRect(origin: .zero, size: size),
-            scale: scale
+            bounds: CGRect(origin: .zero, size: size)
         )
 
         // Fixes video surface visibility with transparent & opaque views in SDLSurface above

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -24,7 +24,7 @@ public final class UIScreen {
     internal var rawPointer: UnsafeMutablePointer<GPU_Target>!
 
     public let bounds: CGRect
-    private(set) public var scale: CGFloat {
+    public var scale: CGFloat {
         return UIScreen.lastKnownScale
     }
 

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -30,7 +30,8 @@ public final class UIScreen {
 
     internal static var lastKnownScale: CGFloat = 1.0
 
-    private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect) {
+    private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect, scale: CGFloat) {
+        UIScreen.lastKnownScale = scale
         self.rawPointer = renderTarget
         self.bounds = bounds
     }
@@ -87,15 +88,14 @@ public final class UIScreen {
         let scale = CGFloat(gpuTarget.pointee.base_h) / CGFloat(gpuTarget.pointee.h)
         #endif
 
-        UIScreen.lastKnownScale = scale
-
         if size == .zero {
             preconditionFailure("You need window dimensions to run")
         }
 
         self.init(
             renderTarget: gpuTarget,
-            bounds: CGRect(origin: .zero, size: size)
+            bounds: CGRect(origin: .zero, size: size),
+            scale: scale
         )
 
         // Fixes video surface visibility with transparent & opaque views in SDLSurface above
@@ -187,10 +187,10 @@ extension UIScreen {
         bounds: CGRect = CGRect(origin: .zero, size: .samsungGalaxyS7),
         scale: CGFloat
     ) -> UIScreen {
-        UIScreen.lastKnownScale = scale
         return UIScreen(
             renderTarget: nil,
-            bounds: bounds
+            bounds: bounds,
+            scale: scale
         )
     }
 }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -187,10 +187,10 @@ extension UIScreen {
         bounds: CGRect = CGRect(origin: .zero, size: .samsungGalaxyS7),
         scale: CGFloat
     ) -> UIScreen {
+        UIScreen.lastKnownScale = scale
         return UIScreen(
             renderTarget: nil,
-            bounds: bounds,
-            scale: scale
+            bounds: bounds
         )
     }
 }

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -140,7 +140,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     public init(frame: CGRect) {
         self.layer = type(of: self).layerClass.init()
-        self.layer.contentsScale = UIScreen.main.scale
+        self.layer.contentsScale = UIScreen.lastKnownScale
         super.init()
 
         self.layer.delegate = self


### PR DESCRIPTION
Fixes crashes when accessing a deinited UIScreen

**Type of change:** Bug fix

## Motivation (current vs expected behavior)

Sometimes application code will init objects that inadvertently access `UIScreen.main`, usually for `UIScreen.main.scale`. Since we never update the screen scale after init, we can cache the last known value and use it internally for our calculations. This will reduce the number of crashes we see without affecting behaviour.




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
