### PR TITLE
simplify onNativeTouch method

### DIFF
--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -252,7 +252,7 @@ public func onNativeTouch(
         SDL_TouchFingerEvent(
             type: eventType.rawValue,
             timestamp: UInt32(timestampMs),
-            touchId: Int64(touchDeviceId),
+            touchId: Int64(touchDeviceId), // some arbitrary number, stays the same per device
             fingerId: Int64(pointerFingerId),
             x: x / Float(UIScreen.lastKnownScale),
             y: y / Float(UIScreen.lastKnownScale),

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -7,6 +7,7 @@
 //
 
 import SDL
+import JNI
 import struct Foundation.TimeInterval
 
 extension UIApplication {
@@ -228,16 +229,18 @@ import JNI
 public func onNativeTouch(
     env: UnsafeMutablePointer<JNIEnv?>?,
     view: JavaObject?,
-    action: JavaInt,
-    x: JavaFloat,
-    y: JavaFloat,
-    timestampMs: JavaLong
+    touchParameters: JavaObject
 ) {
     if env == nil || view == nil {
         // We're in an invalid state where the JNI has exploded somehow
         // Passing anything on to UIKit now would probably lead to a crash
         return
     }
+
+    let action: JavaInt = try! jni.GetField("action", from: touchParameters)
+    let x: JavaFloat = try! jni.GetField("x", from: touchParameters)
+    let y: JavaFloat = try! jni.GetField("y", from: touchParameters)
+    let timestampMs: JavaLong = try! jni.GetField("timestamp", from: touchParameters)
 
     guard let eventType = SDL_EventType.eventFrom(androidAction: action)
     else { return }

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -228,12 +228,9 @@ import JNI
 public func onNativeTouch(
     env: UnsafeMutablePointer<JNIEnv?>?,
     view: JavaObject?,
-    touchDeviceID: JavaInt,
-    pointerFingerID: JavaInt,
     action: JavaInt,
     x: JavaFloat,
     y: JavaFloat,
-    pressure: JavaFloat,
     timestampMs: JavaLong
 ) {
     if env == nil || view == nil {
@@ -249,13 +246,13 @@ public func onNativeTouch(
         SDL_TouchFingerEvent(
             type: eventType.rawValue,
             timestamp: UInt32(timestampMs),
-            touchId: Int64(touchDeviceID), // some arbitrary number, stays the same per device
-            fingerId: Int64(pointerFingerID),
+            touchId: 0,
+            fingerId: 0,
             x: x / Float(UIScreen.lastKnownScale),
             y: y / Float(UIScreen.lastKnownScale),
             dx: 0,
             dy: 0,
-            pressure: pressure
+            pressure: 0
         )
     )
 

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -237,9 +237,12 @@ public func onNativeTouch(
         return
     }
 
+    let touchDeviceId: JavaInt = try! jni.GetField("touchDeviceId", from: touchParameters)
+    let pointerFingerId: JavaInt = try! jni.GetField("pointerFingerId", from: touchParameters)
     let action: JavaInt = try! jni.GetField("action", from: touchParameters)
     let x: JavaFloat = try! jni.GetField("x", from: touchParameters)
     let y: JavaFloat = try! jni.GetField("y", from: touchParameters)
+    let pressure: JavaFloat = try! jni.GetField("pressure", from: touchParameters)
     let timestampMs: JavaLong = try! jni.GetField("timestamp", from: touchParameters)
 
     guard let eventType = SDL_EventType.eventFrom(androidAction: action)
@@ -249,13 +252,13 @@ public func onNativeTouch(
         SDL_TouchFingerEvent(
             type: eventType.rawValue,
             timestamp: UInt32(timestampMs),
-            touchId: 0,
-            fingerId: 0,
+            touchId: Int64(touchDeviceId),
+            fingerId: Int64(pointerFingerId),
             x: x / Float(UIScreen.lastKnownScale),
             y: y / Float(UIScreen.lastKnownScale),
             dx: 0,
             dy: 0,
-            pressure: 0
+            pressure: pressure
         )
     )
 

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -62,7 +62,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
     // SDLOnTouchListener conformance
     external override fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
-    external override fun onNativeTouchUIKit(action: Int, x: Float, y: Float, t: Long)
+    external override fun onNativeTouchUIKit(touchParameters: TouchParameters)
     override var mWidth: Float = 1.0f // Keep track of the surface size to normalize touch events
     override var mHeight: Float = 1.0f // Start with non-zero values to avoid potential division by zero
 

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -62,7 +62,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
 
     // SDLOnTouchListener conformance
     external override fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
-    external override fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
+    external override fun onNativeTouchUIKit(action: Int, x: Float, y: Float, t: Long)
     override var mWidth: Float = 1.0f // Keep track of the surface size to normalize touch events
     override var mHeight: Float = 1.0f // Start with non-zero values to avoid potential division by zero
 

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -69,7 +69,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
         // check if we have focus because of a crash when re-entering the player 
         // from a background state while touching (JNIEnv dead)
         if (this.mHasFocus) {
-            this.onNativeTouchUIKit(TouchParameters(action, x, y, t))
+            this.onNativeTouchUIKit(TouchParameters(touchDevId, pointerFingerId, action, x, y, p, t))
         }
     }
 }
@@ -87,4 +87,12 @@ private fun MotionEvent.touchValues(i: Int): TouchValues {
     )
 }
 
-class TouchParameters(val action: Int, val x: Float, val y: Float, val timestamp: Long)
+class TouchParameters(
+    val touchDeviceId: Int,
+    val pointerFingerId: Int,
+    val action: Int,
+    val x: Float,
+    val y: Float,
+    val pressure: Float,
+    val timestamp: Long
+)

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -1,5 +1,6 @@
 package main.java.org.libsdl.app
 
+import android.text.method.Touch
 import android.view.InputDevice
 import android.view.MotionEvent
 import android.view.View
@@ -14,7 +15,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
     var mHasFocus: Boolean
 
     fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
-    fun onNativeTouchUIKit(action: Int, x: Float, y: Float, t: Long)
+    fun onNativeTouchUIKit(touchParameters: TouchParameters)
 
     // Touch events
     override fun onTouch(v: View, event: MotionEvent): Boolean {
@@ -68,7 +69,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
         // check if we have focus because of a crash when re-entering the player 
         // from a background state while touching (JNIEnv dead)
         if (this.mHasFocus) {
-            this.onNativeTouchUIKit(action, x, y, t)
+            this.onNativeTouchUIKit(TouchParameters(action, x, y, t))
         }
     }
 }
@@ -85,3 +86,5 @@ private fun MotionEvent.touchValues(i: Int): TouchValues {
             min(this.getPressure(i), 1.0f)
     )
 }
+
+class TouchParameters(val action: Int, val x: Float, val y: Float, val timestamp: Long)

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -14,7 +14,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
     var mHasFocus: Boolean
 
     fun onNativeMouse(button: Int, action: Int, x: Float, y: Float)
-    fun onNativeTouchUIKit(touchDevId: Int, pointerFingerId: Int, action: Int, x: Float, y: Float, p: Float, t: Long)
+    fun onNativeTouchUIKit(action: Int, x: Float, y: Float, t: Long)
 
     // Touch events
     override fun onTouch(v: View, event: MotionEvent): Boolean {
@@ -68,7 +68,7 @@ interface SDLOnTouchListener: View.OnTouchListener {
         // check if we have focus because of a crash when re-entering the player 
         // from a background state while touching (JNIEnv dead)
         if (this.mHasFocus) {
-            this.onNativeTouchUIKit(touchDevId, pointerFingerId, action, x, y, p, t)
+            this.onNativeTouchUIKit(action, x, y, t)
         }
     }
 }


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Get rid of unused function parameters to maybe fix a crash in `onNativeTouch` function.

**trace from bugsnag** 
```
SIGTRAP Trace/breakpoint trap 
    build/arm64-v8a/<compiler-generated>:265 UIKit.onNativeTouch(env
```

**trace from google play**
```
#00  pc 00000000000a17b0  /data/app/com.flowkey.app-Cfv7n2a_ZlqbZd_l5StZdg==/lib/arm64/libUIKit.so ($s5UIKit13onNativeTouch3env4view13touchDeviceID013pointerFingerI06action1x1y8pressure11timestampMsySpySPySo18JNINativeInterfaceVGSgGSg_SvSgs5Int32VA2TS3fs5Int64VtF+244)
  #00  pc 0000000000162ee4  /data/app/com.flowkey.app-Cfv7n2a_ZlqbZd_l5StZdg==/oat/arm64/base.odex (art_jni_trampoline+180)
```

https://app.bugsnag.com/flowkey-gmbh/mobile-app/errors/61a30ddf3b2d9500071b9eea?filters[app.release_stage]=production&filters[release.seen_in][]=2.37.3&filters[release.seen_in][]=2.37.3%20(*)&filters[event.unhandled]=true




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
