### PR TITLE
navigation bar items: take safe area insets into account

### DIFF
--- a/Sources/UINavigationBar.swift
+++ b/Sources/UINavigationBar.swift
@@ -59,15 +59,17 @@ open class UINavigationBar: UIView {
     }
 
     open override func layoutSubviews() {
+        let safeAreaInsets = UIWindow.getSafeAreaInsets()
+
         backButton.sizeToFit()
-        backButton.frame.origin.x = horizontalMargin
+        backButton.frame.origin.x = horizontalMargin + safeAreaInsets.left
         backButton.center.y = bounds.midY
 
         titleLabel.sizeToFit()
         titleLabel.center = CGPoint(x: bounds.midX, y: bounds.midY)
 
         rightButton.sizeToFit()
-        rightButton.frame.maxX = bounds.maxX - horizontalMargin
+        rightButton.frame.maxX = bounds.maxX - horizontalMargin - safeAreaInsets.right
         rightButton.center.y = bounds.midY
     }
 


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)
The items in the UINavigationBar implementation should take the safe area into account.

![Screenshot_20220707-134600](https://user-images.githubusercontent.com/2410252/177766545-a476637b-a916-41dd-853b-55efb1cf7403.png)




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
