### PR TITLE
fix bottom insets when using non translucent navigation

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -104,12 +104,13 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
         val zeroRect = RectF(0f, 0f, 0f, 0f)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            val insets = rootView.rootWindowInsets?.getInsets(
-                WindowInsets.Type.displayCutout() or
-                WindowInsets.Type.navigationBars()
-            ) ?: return zeroRect
+            val activity = context as Activity
+            val typeMask =
+                if (activity.window.navigationBarColor == Color.TRANSPARENT) WindowInsets.Type.displayCutout() or WindowInsets.Type.navigationBars()
+                else WindowInsets.Type.displayCutout()
 
-            val density = getDeviceDensity().toFloat()
+            val insets = rootWindowInsets?.getInsets(typeMask) ?: return zeroRect
+            val density = getDeviceDensity()
             return RectF(
                 insets.left.toFloat() / density,
                 insets.top.toFloat() / density,


### PR DESCRIPTION
**Type of change:** UX

## Motivation (current vs expected behavior)
Only includes insets for navigation bars when navigation color is set to transparent.

![2022-07-26_10 54 51](https://user-images.githubusercontent.com/5617793/180966333-ca7d87b9-0c0b-4827-99c4-51c79486a6b1.png)






## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
