### PR TITLE
process pending events/tasks after `nativeDestroyScreen`

### DIFF
--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -361,6 +361,9 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
         onNativeSurfaceDestroyed()
         nativeDestroyScreen()
         removeFrameCallback()
+
+        // renderer should now be destroyed but we need to process events once more to clean up
+        this.nativeProcessEventsAndRender()
     }
 
     /** Called by SDL using JNI. */


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
process pending events/tasks after `nativeDestroyScreen`


<img width="760" alt="Screenshot 2022-12-05 at 01 16 58" src="https://user-images.githubusercontent.com/5617793/205526194-db3476a2-a47a-48dc-9b3d-8245d6bd7ede.png">



## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
