### PR TITLE
Truncate timestamps if needed, start timestamps from session start rather than system uptime

### DIFF
--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -244,12 +244,12 @@ public func onNativeTouch(
     let pressure: JavaFloat = try! jni.GetField("pressure", from: touchParameters)
     let timestampMs: JavaLong = try! jni.GetField("timestamp", from: touchParameters)
 
-    guard
-        let eventType = SDL_EventType.eventFrom(androidAction: action),
-        let screenScale = UIScreen.main?.scale
+    guard let eventType = SDL_EventType.eventFrom(androidAction: action)
     else { return }
 
     Task { @MainActor in
+        guard let screenScale = UIScreen.main?.scale else { return }
+
         var event = SDL_Event(tfinger:
             SDL_TouchFingerEvent(
                 type: eventType.rawValue,

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -11,6 +11,7 @@ import android.view.KeyEvent.*
 import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Build
+import android.os.SystemClock
 import main.java.org.libsdl.app.*
 
 private const val TAG = "SDLActivity"
@@ -45,6 +46,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
     private var mSurface: SurfaceView
     private var mIsSurfaceReady = false
     override var mHasFocus = false
+    override var sessionStartTime: Long = SystemClock.uptimeMillis()
 
     private external fun nativeProcessEventsAndRender()
     private external fun nativeInit(): Int

--- a/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
+++ b/src/main/java/org/libsdl/app/SDLOnTouchListener.kt
@@ -1,5 +1,6 @@
 package main.java.org.libsdl.app
 
+import android.os.SystemClock
 import android.text.method.Touch
 import android.view.InputDevice
 import android.view.MotionEvent
@@ -9,7 +10,7 @@ import kotlin.math.min
 
 
 interface SDLOnTouchListener: View.OnTouchListener {
-
+    var sessionStartTime: Long
     var mWidth: Float
     var mHeight: Float
     var mHasFocus: Boolean
@@ -22,7 +23,11 @@ interface SDLOnTouchListener: View.OnTouchListener {
         /* Ref: http://developer.android.com/training/gestures/multi.html */
         val touchDevId = event.deviceId
         val action = event.actionMasked
-        val timestamp = event.eventTime
+
+        // we subtract sessionStartTime to reduce the likelihood
+        // that timestamp will overflow out of a UInt32 in Swift
+        // (which will occur after 49 days of uptime otherwise)
+        val timestamp = event.eventTime - sessionStartTime
 
         if (event.source == InputDevice.SOURCE_MOUSE && SDLActivity.mSeparateMouseAndTouch) {
             val mouseButton = try { event.buttonState } catch (e: Exception) { 1 } // 1 is left button


### PR DESCRIPTION
Fixes crash in `onNativeTouch`

**Type of change:** Bug fix

## Motivation (current vs expected behavior)

The dreaded crash in `onNativeTouch` is our longest-standing and most prevalent crash on Android, and surely the most annoying too because reinstalling the app doesn’t even help, even if it was working just a moment ago.

Here’s the thing: when the user presses the screen, we need to know when that happened so we can measure things like acceleration when dragging. Android gives us that number in milliseconds since the device was switched on.

Now the problem: due to reasons out of our control, SDL only accepts values up to 2^32 (about 4.3 billion) for the timestamp. But since it’s measured since the device started and not since the app started, it’s totally expected that that number can be reached: indeed, 49.7 days after switching on the device, the number of milliseconds will be higher than the number a `UInt32` can accept without overflow. So – with the code how it is at present – every time a touch event is registered from then on, the app will crash. And no amount of restarting or reinstalling the app will fix it. Only restarting the device!

This has probably become more and more relevant over the years as devices become more stable and are left on for longer periods. I’m actually amazed that the crash doesn’t happen more often than it does!

This PR fixes that issue in two ways:

1. By initing the UInt32 with `truncatingIfNeeded` – this will ensure the conversion will never crash. Instead, it will effectively wrap around from 2^32 back to 0. That has the potential for some huge negative time deltas, which might lead to glitches, so also:
2. By basing the timestamp on the init time of `SDLActivity`, rather than on when the system booted. This will ensure there will be no weirdness if you are running the app after 49.7 days of system uptime. Conversely, it is much less likely that any given app session will be up for 49.7 days. 

I also added a defensive check to ensure that `UIScreen.main` exists before posting any events.
And I fixed some formatting weirdness left over from a previous PR – I can recommend hiding whitespace changes while reviewing this PR.


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
