### PR TITLE
update sdks of sample apps, fix non null assertion in kotlin code

### DIFF
--- a/samples/getting-started/android/app/build.gradle
+++ b/samples/getting-started/android/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.example"
         minSdkVersion 24
-        targetSdkVersion 31
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/samples/getting-started/android/build.gradle
+++ b/samples/getting-started/android/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.5.31'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/samples/getting-started/android/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/getting-started/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/src/main/java/org/libsdl/app/SDLActivity.kt
+++ b/src/main/java/org/libsdl/app/SDLActivity.kt
@@ -237,7 +237,7 @@ open class SDLActivity internal constructor (context: Context?) : RelativeLayout
     @Suppress("unused")
     fun inputGetInputDeviceIds(sources: Int): IntArray {
         return InputDevice.getDeviceIds().fold(intArrayOf(0)) { result: IntArray, id: Int ->
-            val device = InputDevice.getDevice(id)
+            val device = InputDevice.getDevice(id) ?: return result
             return if (device.sources and sources != 0) (result + device.id) else result
         }
     }


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Fixes a compilation assertion in SDLActivity

```
> Task :UIKit:compileDebugKotlin FAILED
e: file:///mobile-app/RNPlayerComponent/NativePlayer/UIKit/src/main/java/org/libsdl/app/SDLActivity.kt:241:30 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type InputDevice?
e: file:///mobile-app/RNPlayerComponent/NativePlayer/UIKit/src/main/java/org/libsdl/app/SDLActivity.kt:241:73 Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type InputDevice?
```






## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
