### PR TITLE
Improve UIView.safeAreaInsets

### DIFF
--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -43,7 +43,9 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
         }
     }
 
-    open internal(set) var safeAreaInsets: UIEdgeInsets = .zero
+    public var safeAreaInsets: UIEdgeInsets {
+        return UIWindow.getSafeAreaInsets()
+    }
 
     open var mask: UIView? {
         didSet {

--- a/Sources/UIWindow.swift
+++ b/Sources/UIWindow.swift
@@ -19,7 +19,6 @@ public class UIWindow: UIView {
     }
 
     open func makeKeyAndVisible() {
-        self.safeAreaInsets = UIWindow.getSafeAreaInsets()
         UIApplication.shared?.keyWindow = self
 
         if let viewController = rootViewController {


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** <!-- e.g. Bug fix, feature, docs update, ... -->

## Motivation (current vs expected behavior)

Make `UIView.safeAreaInsets` a computed property which always returns the current insets  from the Android API. This will reflect changes when the device orientation changes.




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
