### PR TITLE
Fix 1-px edge noise on Android with fractional density

### DIFF
--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -84,9 +84,9 @@ extension UIScreen {
 
     func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
         if cornerRadius >= 1 {
-            GPU_RectangleRoundFilled(rawPointer, rect.gpuRect(scale: scale), cornerRadius: Float(cornerRadius), color: color.sdlColor)
+            GPU_RectangleRoundFilled(rawPointer, rect.gpuRect(target: rawPointer), cornerRadius: Float(cornerRadius), color: color.sdlColor)
         } else {
-            GPU_RectangleFilled(rawPointer, rect.gpuRect(scale: scale), color: color.sdlColor)
+            GPU_RectangleFilled(rawPointer, rect.gpuRect(target: rawPointer), color: color.sdlColor)
         }
     }
 
@@ -99,7 +99,7 @@ extension UIScreen {
             y: rect.origin.y + offset,
             width: rect.size.width - offset,
             height: rect.size.height - offset
-        ).gpuRect(scale: scale)
+        ).gpuRect(target: rawPointer)
 
         GPU_SetLineThickness(Float(lineThickness))
         GPU_Rectangle(rawPointer, scaledGpuRect, color: lineColor.sdlColor)
@@ -115,7 +115,7 @@ extension UIScreen {
                 y: rect.origin.y + offset,
                 width: rect.size.width - offset,
                 height: rect.size.height - offset
-            ).gpuRect(scale: scale)
+            ).gpuRect(target: rawPointer)
 
             GPU_SetLineThickness(Float(lineThickness))
             GPU_RectangleRound(rawPointer, scaledGpuRect, cornerRadius: Float(cornerRadius), color: lineColor.sdlColor)
@@ -136,17 +136,22 @@ extension UIScreen {
             return GPU_UnsetClip(rawPointer)
         }
 
-        GPU_SetClipRect(rawPointer, clippingRect.gpuRect(scale: scale))
+        GPU_SetClipRect(rawPointer, clippingRect.gpuRect(target: rawPointer))
     }
 }
 
 private extension CGRect {
-    func gpuRect(scale: CGFloat) -> GPU_Rect {
+    // Snap to physical pixel boundaries using the GPU target's per-axis ratios —
+    // a single `UIScreen.scale` is wrong when drawable_w/target_w ≠ drawable_h/target_h
+    // (any fractional density rounds the two axes by different amounts).
+    func gpuRect(target: UnsafeMutablePointer<GPU_Target>!) -> GPU_Rect {
+        let scaleX = CGFloat(target.pointee.context.pointee.drawable_w) / CGFloat(target.pointee.w)
+        let scaleY = CGFloat(target.pointee.context.pointee.drawable_h) / CGFloat(target.pointee.h)
         return GPU_Rect(
-            x: Float((self.origin.x * scale).rounded() / scale),
-            y: Float((self.origin.y * scale).rounded() / scale),
-            w: Float((self.size.width * scale).rounded() / scale),
-            h: Float((self.size.height * scale).rounded() / scale)
+            x: Float((self.origin.x * scaleX).rounded() / scaleX),
+            y: Float((self.origin.y * scaleY).rounded() / scaleY),
+            w: Float((self.size.width * scaleX).rounded() / scaleX),
+            h: Float((self.size.height * scaleY).rounded() / scaleY)
         )
     }
 }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -84,9 +84,9 @@ extension UIScreen {
 
     func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
         if cornerRadius >= 1 {
-            GPU_RectangleRoundFilled(rawPointer, rect.gpuRect(target: rawPointer), cornerRadius: Float(cornerRadius), color: color.sdlColor)
+            GPU_RectangleRoundFilled(rawPointer, gpuRect(rect), cornerRadius: Float(cornerRadius), color: color.sdlColor)
         } else {
-            GPU_RectangleFilled(rawPointer, rect.gpuRect(target: rawPointer), color: color.sdlColor)
+            GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
         }
     }
 
@@ -94,12 +94,12 @@ extension UIScreen {
         // we want to render the outline 'inside' the rect rather
         // than exceeding the bounds when lineThickness is bigger than 1
         let offset = lineThickness / 2
-        let scaledGpuRect = CGRect(
+        let scaledGpuRect = gpuRect(CGRect(
             x: rect.origin.x + offset,
             y: rect.origin.y + offset,
             width: rect.size.width - offset,
             height: rect.size.height - offset
-        ).gpuRect(target: rawPointer)
+        ))
 
         GPU_SetLineThickness(Float(lineThickness))
         GPU_Rectangle(rawPointer, scaledGpuRect, color: lineColor.sdlColor)
@@ -110,12 +110,12 @@ extension UIScreen {
             // we want to render the outline 'inside' the rect rather
             // than exceeding the bounds when lineThickness is bigger than 1
             let offset = lineThickness / 2
-            let scaledGpuRect = CGRect(
+            let scaledGpuRect = gpuRect(CGRect(
                 x: rect.origin.x + offset,
                 y: rect.origin.y + offset,
                 width: rect.size.width - offset,
                 height: rect.size.height - offset
-            ).gpuRect(target: rawPointer)
+            ))
 
             GPU_SetLineThickness(Float(lineThickness))
             GPU_RectangleRound(rawPointer, scaledGpuRect, cornerRadius: Float(cornerRadius), color: lineColor.sdlColor)
@@ -136,22 +136,22 @@ extension UIScreen {
             return GPU_UnsetClip(rawPointer)
         }
 
-        GPU_SetClipRect(rawPointer, clippingRect.gpuRect(target: rawPointer))
+        GPU_SetClipRect(rawPointer, gpuRect(clippingRect))
     }
 }
 
-private extension CGRect {
+private extension UIScreen {
     // Snap to physical pixel boundaries using the GPU target's per-axis ratios —
     // a single `UIScreen.scale` is wrong when drawable_w/target_w ≠ drawable_h/target_h
     // (any fractional density rounds the two axes by different amounts).
-    func gpuRect(target: UnsafeMutablePointer<GPU_Target>!) -> GPU_Rect {
-        let scaleX = CGFloat(target.pointee.context.pointee.drawable_w) / CGFloat(target.pointee.w)
-        let scaleY = CGFloat(target.pointee.context.pointee.drawable_h) / CGFloat(target.pointee.h)
+    func gpuRect(_ rect: CGRect) -> GPU_Rect {
+        let scaleX = CGFloat(rawPointer.pointee.context.pointee.drawable_w) / CGFloat(rawPointer.pointee.w)
+        let scaleY = CGFloat(rawPointer.pointee.context.pointee.drawable_h) / CGFloat(rawPointer.pointee.h)
         return GPU_Rect(
-            x: Float((self.origin.x * scaleX).rounded() / scaleX),
-            y: Float((self.origin.y * scaleY).rounded() / scaleY),
-            w: Float((self.size.width * scaleX).rounded() / scaleX),
-            h: Float((self.size.height * scaleY).rounded() / scaleY)
+            x: Float((rect.origin.x * scaleX).rounded() / scaleX),
+            y: Float((rect.origin.y * scaleY).rounded() / scaleY),
+            w: Float((rect.size.width * scaleX).rounded() / scaleX),
+            h: Float((rect.size.height * scaleY).rounded() / scaleY)
         )
     }
 }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -91,10 +91,16 @@ public final class UIScreen {
         }
 
         #if os(Android)
-        let scale = androidScreenDimension.scale
-        GPU_SetVirtualResolution(gpuTarget, UInt16(size.width / scale), UInt16(size.height / scale))
-        size.width /= scale
-        size.height /= scale
+        // Snap bounds to the rounded virtual resolution and back-derive `scale` so
+        // `bounds.width * scale == physical_width` exactly — otherwise a fractional
+        // density (e.g. 2.125) leaves the rightmost physical column un-rasterised.
+        let densityScale = androidScreenDimension.scale
+        let virtualWidth = UInt16((size.width / densityScale).rounded())
+        let virtualHeight = UInt16((size.height / densityScale).rounded())
+        GPU_SetVirtualResolution(gpuTarget, virtualWidth, virtualHeight)
+        let scale = size.width / CGFloat(virtualWidth)
+        size.width = CGFloat(virtualWidth)
+        size.height = CGFloat(virtualHeight)
         #else
         // Mac:
         let scale = CGFloat(gpuTarget.pointee.base_h) / CGFloat(gpuTarget.pointee.h)


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)

On devices reporting a non-integer density (e.g. Galaxy Tab S9 with `density=2.125`), a 1-px band of GPU garbage was visible at the right/bottom edges of the screen — sometimes random, sometimes leftover content from earlier frames. The noise got worse after orientation changes.

## Root cause

`UIScreen.bounds.width = physical_width / density` was fractional (e.g. `2560 / 2.125 = 1204.7`), but `GPU_SetVirtualResolution` only takes `UInt16` so `target->w` was rounded to `1205`. SDL-gpu's orthographic projection maps virtual `x = target->w` to NDC `+1`. Drawing a view at the *fractional* `bounds.width` landed at NDC ≈ `0.9994`, missing the rightmost physical pixel column entirely — those pixels never got cleared and never got drawn, so the SurfaceView composited the underlying framebuffer through them.

A secondary problem: `gpuRect` used a single `UIScreen.scale` to snap to physical pixel boundaries, but `drawable_w/target->w` and `drawable_h/target->h` are subtly different on non-integer densities. Using the x-ratio for y snapped the bottom edge ~0.2 virtual-px short of the viewport.

## Fix

- **`Sources/UIScreen.swift`** — snap `bounds.size` to the rounded virtual resolution and back-derive `scale` from the rounded value, so `bounds.width * scale == physical_width` *exactly*.
- **`Sources/UIScreen+render.swift`** — `gpuRect` now reads per-axis ratios directly from the GPU target (`drawable_w/target->w`, `drawable_h/target->h`) instead of a single `UIScreen.scale`.

## Screenshots


https://github.com/user-attachments/assets/f88f0990-32db-4c30-a1fa-70676ee3f589

<img width="3024" height="4032" alt="IMG_7536" src="https://github.com/user-attachments/assets/a7f8e678-0094-4cb5-94c2-7527352cc6a2" />




## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
