### PR TITLE
Fix video seeks landing on the nearest keyframe instead of the requested time

### DIFF
--- a/src/main/java/org/uikit/VideoJNI.kt
+++ b/src/main/java/org/uikit/VideoJNI.kt
@@ -70,7 +70,7 @@ class AVPlayer(sdlView: SDLActivity, asset: AVURLAsset) {
                 newPosition: Player.PositionInfo,
                 reason: Int
             ) {
-                if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+                if (reason == Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT) {
                     isSeeking = false
                     val delta = (newPosition.positionMs - desiredSeekPosition).absoluteValue
                     if (delta > 50) {


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)
Fixes an issue where video seeks would be landing on the nearest keyframe instead of the requested time. This change make seeking more exact





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
