### PR TITLE
[UIFont] Add a fallback scale to UIScreen.main.scale if the screen is inactive

### DIFF
--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -27,7 +27,7 @@ open class UIFont {
 
     public init?(name: String, size: CGFloat) {
         let name = name.lowercased()
-        let size = Int32(size * UIScreen.main.scale)
+        let size = Int32(size * (UIScreen.main?.scale ?? 2))
 
         self.fontName = name
         self.pointSize = CGFloat(size)


### PR DESCRIPTION
**Type of change:** Bug fix

## Motivation (current vs expected behavior)

Apps will crash if fonts are constructed while UIScreen is deinited (e.g. the app is in the background). This change provides a sane fallback as a default to prevent crashes (at the potential cost of correctness in the worst case).