### PR TITLE
Add fallback to UIScreen.main.scale and properly deinit CGImage

### DIFF
--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -112,7 +112,14 @@ public class CGImage {
     }
 
     deinit {
-        GPU_FreeImage(rawPointer)
+        // `GPU_FreeImage` makes GL calls that are only valid on the main (GL) thread, and only
+        // while a context exists. `CGImage` isn't `@MainActor`, so it can be released off-main or
+        // after teardown — hop to the main actor and skip the free if the screen is already gone.
+        let pointer = rawPointer
+        Task { @MainActor in
+            guard UIScreen.main != nil else { return }
+            GPU_FreeImage(pointer)
+        }
     }
 
     public func pngData() -> Data? {

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -135,7 +135,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     public init(frame: CGRect) {
         self.layer = type(of: self).layerClass.init()
-        self.layer.contentsScale = UIScreen.main.scale
+        self.layer.contentsScale = UIScreen.main?.scale ?? 2
         super.init()
 
         self.layer.delegate = self


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->

**Type of change:** bugfix

## Motivation (current vs expected behavior)
- Deinit CGImage on main thread
- Provide fallback for UIScreen.main.scale in UIview init



## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
