### PR TITLE
improve text rendering

### DIFF
--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -111,11 +111,17 @@ public class FontRenderer {
         return false
     }
 
-    func render(_ text: String?, color: UIColor, wrapLength: Int = 0) -> CGImage? {
+    func render(_ text: String?, color: UIColor, wrapLength: Int = 0, alignment: NSTextAlignment = .left) -> CGImage? {
         guard let text = text else { return nil }
 
         if wrapLength <= 0 && needsFallback(text) {
             return renderWithFallback(text, color: color)
+        }
+
+        // SDL_ttf renders wrapped lines left-aligned only. For centered/right text we compose the
+        // lines ourselves so each line is aligned within the wrap width.
+        if wrapLength > 0 && alignment != .left {
+            return renderWrapped(wrapLines(of: text, wrapLength: wrapLength), color: color, wrapLength: wrapLength, alignment: alignment)
         }
 
         guard
@@ -126,6 +132,85 @@ public class FontRenderer {
 
         defer { SDL_FreeSurface(surface) }
         return CGImage(surface: surface)
+    }
+
+    /// Returns `text` truncated with a trailing ellipsis so it fits within `maxWidth` (pixels).
+    /// Returns `text` unchanged when it already fits (or `maxWidth <= 0`).
+    func truncatedText(_ text: String, toWidth maxWidth: Int) -> String {
+        guard maxWidth > 0 else { return text }
+
+        var width: Int32 = 0
+        var height: Int32 = 0
+        TTF_SizeUTF8(rawPointer, text, &width, &height)
+        if Int(width) <= maxWidth { return text }
+
+        let ellipsis = "…"
+        var characters = Array(text)
+        while !characters.isEmpty {
+            characters.removeLast()
+            let candidate = String(characters) + ellipsis
+            TTF_SizeUTF8(rawPointer, candidate, &width, &height)
+            if Int(width) <= maxWidth { return candidate }
+        }
+        return ellipsis
+    }
+
+    /// Greedily wraps `text` into lines that each fit within `wrapLength` (pixels), breaking on
+    /// spaces and honouring explicit newlines. Matches the line breaking counted by `multilineSize`.
+    func wrapLines(of text: String, wrapLength: Int) -> [String] {
+        guard wrapLength > 0 else { return [text] }
+
+        var lines: [String] = []
+        for paragraph in text.components(separatedBy: "\n") {
+            var currentLine = ""
+            for word in paragraph.split(separator: " ", omittingEmptySubsequences: false).map(String.init) {
+                let candidate = currentLine.isEmpty ? word : currentLine + " " + word
+                var candidateWidth: Int32 = 0
+                var candidateHeight: Int32 = 0
+                TTF_SizeUTF8(rawPointer, candidate, &candidateWidth, &candidateHeight)
+
+                if currentLine.isEmpty || Int(candidateWidth) <= wrapLength {
+                    currentLine = candidate
+                } else {
+                    lines.append(currentLine)
+                    currentLine = word
+                }
+            }
+            lines.append(currentLine)
+        }
+        return lines
+    }
+
+    /// Composes pre-wrapped `lines` into a single surface of `wrapLength` width, positioning each
+    /// line according to `alignment`.
+    private func renderWrapped(_ lines: [String], color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
+        let lineSpacing: Int32 = 2
+        let lineHeight = TTF_FontHeight(rawPointer)
+        let totalHeight = Int(lineHeight) * lines.count + Int(lineSpacing) * (lines.count - 1)
+        guard totalHeight > 0 else { return nil }
+
+        guard let target = SDL_CreateRGBSurfaceWithFormat(
+            0, Int32(wrapLength), Int32(totalHeight), 32, UInt32(SDL_PIXELFORMAT_ARGB8888)
+        ) else { return nil }
+        defer { SDL_FreeSurface(target) }
+
+        for (index, line) in lines.enumerated() {
+            guard !line.isEmpty, let surface = TTF_RenderUTF8_Blended(rawPointer, line, color.sdlColor) else { continue }
+            defer { SDL_FreeSurface(surface) }
+
+            SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
+            let lineWidth = surface.pointee.w
+            let x: Int32
+            switch alignment {
+            case .center: x = (Int32(wrapLength) - lineWidth) / 2
+            case .right: x = Int32(wrapLength) - lineWidth
+            case .left: x = 0
+            }
+            var dstRect = SDLRect(x: max(0, x), y: Int32(index) * (lineHeight + lineSpacing), w: lineWidth, h: surface.pointee.h)
+            SDL_UpperBlit(surface, nil, target, &dstRect)
+        }
+
+        return CGImage(surface: target)
     }
 
     private func renderWithFallback(_ text: String, color: UIColor) -> CGImage? {
@@ -259,5 +344,136 @@ extension FontRenderer {
         let combinedLineSpacing = lineSpace * (linesCount - 1)
 
         return CGSize(width: wrapLength, height: combinedTextHeight + combinedLineSpacing)
+    }
+}
+
+// MARK: Multi-font (styled-run) text
+
+/// Lightweight multi-font text: a sequence of (text, font) runs rendered inline with word
+/// wrapping and alignment. Fills the gap left by not having NSAttributedString in this polyfill,
+/// e.g. a bold label followed by a regular value on the same wrapping line.
+@MainActor
+public struct StyledTextRun {
+    public let text: String
+    public let font: UIFont
+
+    public init(_ text: String, font: UIFont) {
+        self.text = text
+        self.font = font
+    }
+}
+
+@MainActor
+extension FontRenderer {
+    private struct WordToken {
+        let text: String
+        let renderer: FontRenderer
+        let width: Int32
+        let spaceWidth: Int32
+        let height: Int32
+    }
+
+    private static let styledLineSpacing: Int32 = 2
+
+    /// Splits runs into space-separated words, each tagged with its own font renderer/metrics.
+    private static func tokenize(_ runs: [StyledTextRun]) -> [WordToken] {
+        var tokens: [WordToken] = []
+        for run in runs {
+            guard let renderer = run.font.fontRenderer else { continue }
+
+            var spaceWidth: Int32 = 0
+            var spaceHeight: Int32 = 0
+            TTF_SizeUTF8(renderer.rawPointer, " ", &spaceWidth, &spaceHeight)
+
+            for word in run.text.split(separator: " ", omittingEmptySubsequences: true).map(String.init) {
+                var width: Int32 = 0
+                var height: Int32 = 0
+                TTF_SizeUTF8(renderer.rawPointer, word, &width, &height)
+                tokens.append(WordToken(text: word, renderer: renderer, width: width, spaceWidth: spaceWidth, height: height))
+            }
+        }
+        return tokens
+    }
+
+    private static func wrap(_ tokens: [WordToken], wrapLength: Int) -> [[WordToken]] {
+        guard wrapLength > 0 else { return tokens.isEmpty ? [] : [tokens] }
+
+        var lines: [[WordToken]] = []
+        var currentLine: [WordToken] = []
+        var currentWidth: Int32 = 0
+
+        for token in tokens {
+            let addedWidth = currentLine.isEmpty ? token.width : token.spaceWidth + token.width
+            if !currentLine.isEmpty && Int(currentWidth + addedWidth) > wrapLength {
+                lines.append(currentLine)
+                currentLine = [token]
+                currentWidth = token.width
+            } else {
+                currentLine.append(token)
+                currentWidth += addedWidth
+            }
+        }
+        if !currentLine.isEmpty { lines.append(currentLine) }
+        return lines
+    }
+
+    private static func lineWidth(_ line: [WordToken]) -> Int32 {
+        line.enumerated().reduce(0) { result, item in
+            result + (item.offset == 0 ? 0 : item.element.spaceWidth) + item.element.width
+        }
+    }
+
+    static func styledRunsSize(_ runs: [StyledTextRun], wrapLength: Int) -> CGSize {
+        let tokens = tokenize(runs)
+        guard !tokens.isEmpty else { return .zero }
+
+        let lineHeight = tokens.map { $0.height }.max() ?? 0
+
+        if wrapLength <= 0 {
+            return CGSize(width: Int(lineWidth(tokens)), height: Int(lineHeight))
+        }
+
+        let lines = wrap(tokens, wrapLength: wrapLength)
+        let height = Int(lineHeight) * lines.count + Int(styledLineSpacing) * max(0, lines.count - 1)
+        return CGSize(width: wrapLength, height: height)
+    }
+
+    static func renderStyledRuns(_ runs: [StyledTextRun], color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
+        let tokens = tokenize(runs)
+        guard !tokens.isEmpty else { return nil }
+
+        let lineHeight = tokens.map { $0.height }.max() ?? 0
+        let lines = wrapLength > 0 ? wrap(tokens, wrapLength: wrapLength) : [tokens]
+        let surfaceWidth = wrapLength > 0 ? Int32(wrapLength) : lineWidth(tokens)
+        let totalHeight = lineHeight * Int32(lines.count) + styledLineSpacing * Int32(max(0, lines.count - 1))
+        guard surfaceWidth > 0, totalHeight > 0 else { return nil }
+
+        guard let target = SDL_CreateRGBSurfaceWithFormat(
+            0, surfaceWidth, totalHeight, 32, UInt32(SDL_PIXELFORMAT_ARGB8888)
+        ) else { return nil }
+        defer { SDL_FreeSurface(target) }
+
+        for (lineIndex, line) in lines.enumerated() {
+            var x: Int32
+            switch alignment {
+            case .center: x = (surfaceWidth - lineWidth(line)) / 2
+            case .right: x = surfaceWidth - lineWidth(line)
+            case .left: x = 0
+            }
+            let y = Int32(lineIndex) * (lineHeight + styledLineSpacing)
+
+            for (index, token) in line.enumerated() {
+                if index > 0 { x += token.spaceWidth }
+                if let surface = TTF_RenderUTF8_Blended(token.renderer.rawPointer, token.text, color.sdlColor) {
+                    SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
+                    var destination = SDLRect(x: max(0, x), y: y, w: surface.pointee.w, h: surface.pointee.h)
+                    SDL_UpperBlit(surface, nil, target, &destination)
+                    SDL_FreeSurface(surface)
+                }
+                x += token.width
+            }
+        }
+
+        return CGImage(surface: target)
     }
 }

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -184,28 +184,18 @@ public class FontRenderer {
     /// Composes pre-wrapped `lines` into a single surface of `wrapLength` width, positioning each
     /// line according to `alignment`.
     private func renderWrapped(_ lines: [String], color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
-        let lineSpacing: Int32 = 2
         let lineHeight = TTF_FontHeight(rawPointer)
-        let totalHeight = Int(lineHeight) * lines.count + Int(lineSpacing) * (lines.count - 1)
-        guard totalHeight > 0 else { return nil }
+        let height = Int32(lines.count) * lineHeight + Int32(max(0, lines.count - 1)) * lineSpacing
 
-        guard let target = SDL_CreateRGBSurfaceWithFormat(
-            0, Int32(wrapLength), Int32(totalHeight), 32, UInt32(SDL_PIXELFORMAT_ARGB8888)
-        ) else { return nil }
-        defer { SDL_FreeSurface(target) }
+        return composeImage(width: Int32(wrapLength), height: height) { target in
+            for (index, line) in lines.enumerated() {
+                guard !line.isEmpty, let surface = TTF_RenderUTF8_Blended(rawPointer, line, color.sdlColor) else { continue }
+                defer { SDL_FreeSurface(surface) }
 
-        for (index, line) in lines.enumerated() {
-            guard !line.isEmpty, let surface = TTF_RenderUTF8_Blended(rawPointer, line, color.sdlColor) else { continue }
-            defer { SDL_FreeSurface(surface) }
-
-            SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
-            let lineWidth = surface.pointee.w
-            let x = alignmentStartX(surfaceWidth: Int32(wrapLength), contentWidth: lineWidth, alignment: alignment)
-            var dstRect = SDLRect(x: max(0, x), y: Int32(index) * (lineHeight + lineSpacing), w: lineWidth, h: surface.pointee.h)
-            SDL_UpperBlit(surface, nil, target, &dstRect)
+                let x = alignmentStartX(surfaceWidth: Int32(wrapLength), contentWidth: surface.pointee.w, alignment: alignment)
+                blit(surface, onto: target, x: max(0, x), y: Int32(index) * (lineHeight + lineSpacing))
+            }
         }
-
-        return CGImage(surface: target)
     }
 
     private func renderWithFallback(_ text: String, color: UIColor) -> CGImage? {
@@ -227,25 +217,16 @@ public class FontRenderer {
         }
 
         let (totalWidth, totalHeight) = size(text)
-        guard totalWidth > 0, totalHeight > 0 else { return nil }
+        return composeImage(width: totalWidth, height: totalHeight) { target in
+            var x: Int32 = 0
+            for run in runs {
+                guard let surface = TTF_RenderUTF8_Blended(run.font, run.text, color.sdlColor) else { continue }
+                defer { SDL_FreeSurface(surface) }
 
-        guard let target = SDL_CreateRGBSurfaceWithFormat(
-            0, totalWidth, totalHeight, 32, UInt32(SDL_PIXELFORMAT_ARGB8888)
-        ) else { return nil }
-        defer { SDL_FreeSurface(target) }
-
-        var x: Int32 = 0
-        for run in runs {
-            guard let surface = TTF_RenderUTF8_Blended(run.font, run.text, color.sdlColor) else { continue }
-            defer { SDL_FreeSurface(surface) }
-
-            SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
-            var dstRect = SDLRect(x: x, y: 0, w: surface.pointee.w, h: surface.pointee.h)
-            SDL_UpperBlit(surface, nil, target, &dstRect)
-            x += surface.pointee.w
+                blit(surface, onto: target, x: x, y: 0)
+                x += surface.pointee.w
+            }
         }
-
-        return CGImage(surface: target)
     }
 }
 
@@ -259,7 +240,6 @@ extension FontRenderer {
     }
 }
 
-// Optimise perf
 /// Horizontal start offset for content of `contentWidth` within `surfaceWidth`, per `alignment`.
 private func alignmentStartX(surfaceWidth: Int32, contentWidth: Int32, alignment: NSTextAlignment) -> Int32 {
     switch alignment {
@@ -269,6 +249,27 @@ private func alignmentStartX(surfaceWidth: Int32, contentWidth: Int32, alignment
     }
 }
 
+/// Creates an ARGB target surface of `width`×`height`, lets `draw` composite glyph surfaces onto
+/// it, and returns a `CGImage` copy. Returns nil for empty dimensions; the target is always freed.
+private func composeImage(width: Int32, height: Int32, draw: (UnsafeMutablePointer<SDLSurface>) -> Void) -> CGImage? {
+    guard width > 0, height > 0 else { return nil }
+    guard let target = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, UInt32(SDL_PIXELFORMAT_ARGB8888)) else { return nil }
+    defer { SDL_FreeSurface(target) }
+    draw(target)
+    return CGImage(surface: target)
+}
+
+/// Blits an already-rendered glyph `surface` onto `target` at (x, y) with no alpha blending.
+private func blit(_ surface: UnsafeMutablePointer<SDLSurface>, onto target: UnsafeMutablePointer<SDLSurface>, x: Int32, y: Int32) {
+    SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
+    var destination = SDLRect(x: x, y: y, w: surface.pointee.w, h: surface.pointee.h)
+    SDL_UpperBlit(surface, nil, target, &destination)
+}
+
+/// Extra vertical padding between wrapped lines, matching SDL_ttf's own 2px inter-line gap.
+private let lineSpacing: Int32 = 2
+
+// Optimise perf
 private let newLineR = Int32("\r".utf8.first!)
 private let newLineN = Int32("\n".utf8.first!)
 
@@ -351,12 +352,6 @@ extension FontRenderer {
     }
 }
 
-// MARK: Attributed text
-
-/// A minimal, Foundation-free stand-in for the slice of `NSAttributedString` we use: text split
-/// into runs that each carry a `.font`. Foundation (and thus the real type) isn't available on
-/// Android/Linux, so we define only the parts we implement, matching Apple's API shape — call
-/// sites are then identical on iOS (real UIKit) and here.
 @MainActor
 public class NSAttributedString {
     public struct Key: Hashable {
@@ -398,8 +393,6 @@ extension FontRenderer {
         let spaceWidth: Int32
         let height: Int32
     }
-
-    private static let styledLineSpacing: Int32 = 2
 
     /// Splits an attributed string into space-separated words, each tagged with its run's font.
     private static func tokenize(_ attributedString: NSAttributedString) -> [WordToken] {
@@ -443,58 +436,51 @@ extension FontRenderer {
         return lines
     }
 
-    private static func lineWidth(_ line: [WordToken]) -> Int32 {
+    private static func getLineWidth(_ line: [WordToken]) -> Int32 {
         line.enumerated().reduce(0) { result, item in
             result + (item.offset == 0 ? 0 : item.element.spaceWidth) + item.element.width
         }
     }
 
-    static func attributedStringSize(_ attributedString: NSAttributedString, wrapLength: Int) -> CGSize {
-        let tokens = tokenize(attributedString)
-        guard !tokens.isEmpty else { return .zero }
-
-        let lineHeight = tokens.map { $0.height }.max() ?? 0
-
-        if wrapLength <= 0 {
-            return CGSize(width: Int(lineWidth(tokens)), height: Int(lineHeight))
-        }
-
-        let lines = wrap(tokens, wrapLength: wrapLength)
-        let height = Int(lineHeight) * lines.count + Int(styledLineSpacing) * max(0, lines.count - 1)
-        return CGSize(width: wrapLength, height: height)
-    }
-
-    static func renderAttributedString(_ attributedString: NSAttributedString, color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
+    /// Tokenizes and wraps `attributedString` (wrapLength 0 = a single unwrapped line). Returns the
+    /// laid-out lines, their shared height, and the resulting surface width — or nil if empty.
+    private static func layoutLines(_ attributedString: NSAttributedString, wrapLength: Int) -> (lines: [[WordToken]], lineHeight: Int32, width: Int32)? {
         let tokens = tokenize(attributedString)
         guard !tokens.isEmpty else { return nil }
 
-        let lineHeight = tokens.map { $0.height }.max() ?? 0
+        let lineHeight = tokens.map(\.height).max() ?? 0
         let lines = wrapLength > 0 ? wrap(tokens, wrapLength: wrapLength) : [tokens]
-        let surfaceWidth = wrapLength > 0 ? Int32(wrapLength) : lineWidth(tokens)
-        let totalHeight = lineHeight * Int32(lines.count) + styledLineSpacing * Int32(max(0, lines.count - 1))
-        guard surfaceWidth > 0, totalHeight > 0 else { return nil }
+        let width = wrapLength > 0 ? Int32(wrapLength) : getLineWidth(tokens)
+        return (lines, lineHeight, width)
+    }
 
-        guard let target = SDL_CreateRGBSurfaceWithFormat(
-            0, surfaceWidth, totalHeight, 32, UInt32(SDL_PIXELFORMAT_ARGB8888)
-        ) else { return nil }
-        defer { SDL_FreeSurface(target) }
+    private static func totalHeight(lineCount: Int, lineHeight: Int32) -> Int32 {
+        lineHeight * Int32(lineCount) + lineSpacing * Int32(max(0, lineCount - 1))
+    }
 
-        for (lineIndex, line) in lines.enumerated() {
-            var x = alignmentStartX(surfaceWidth: surfaceWidth, contentWidth: lineWidth(line), alignment: alignment)
-            let y = Int32(lineIndex) * (lineHeight + styledLineSpacing)
+    static func getAttributedStringSize(_ attributedString: NSAttributedString, wrapLength: Int) -> CGSize {
+        guard let layout = layoutLines(attributedString, wrapLength: wrapLength) else { return .zero }
+        return CGSize(width: Int(layout.width), height: Int(totalHeight(lineCount: layout.lines.count, lineHeight: layout.lineHeight)))
+    }
 
-            for (index, token) in line.enumerated() {
-                if index > 0 { x += token.spaceWidth }
-                if let surface = TTF_RenderUTF8_Blended(token.renderer.rawPointer, token.text, color.sdlColor) {
-                    SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
-                    var destination = SDLRect(x: max(0, x), y: y, w: surface.pointee.w, h: surface.pointee.h)
-                    SDL_UpperBlit(surface, nil, target, &destination)
-                    SDL_FreeSurface(surface)
+    static func renderAttributedString(_ attributedString: NSAttributedString, color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
+        guard let layout = layoutLines(attributedString, wrapLength: wrapLength) else { return nil }
+        let height = totalHeight(lineCount: layout.lines.count, lineHeight: layout.lineHeight)
+
+        return composeImage(width: layout.width, height: height) { target in
+            for (lineIndex, line) in layout.lines.enumerated() {
+                var x = alignmentStartX(surfaceWidth: layout.width, contentWidth: getLineWidth(line), alignment: alignment)
+                let y = Int32(lineIndex) * (layout.lineHeight + lineSpacing)
+
+                for (index, token) in line.enumerated() {
+                    if index > 0 { x += token.spaceWidth }
+                    if let surface = TTF_RenderUTF8_Blended(token.renderer.rawPointer, token.text, color.sdlColor) {
+                        defer { SDL_FreeSurface(surface) }
+                        blit(surface, onto: target, x: max(0, x), y: y)
+                    }
+                    x += token.width
                 }
-                x += token.width
             }
         }
-
-        return CGImage(surface: target)
     }
 }

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -185,7 +185,7 @@ public class FontRenderer {
     /// line according to `alignment`.
     private func renderWrapped(_ lines: [String], color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
         let lineHeight = TTF_FontHeight(rawPointer)
-        let height = Int32(lines.count) * lineHeight + Int32(max(0, lines.count - 1)) * lineSpacing
+        let height = Self.totalHeight(lineCount: lines.count, lineHeight: lineHeight)
 
         return composeImage(width: Int32(wrapLength), height: height) { target in
             for (index, line) in lines.enumerated() {
@@ -285,7 +285,7 @@ extension FontRenderer {
 
     private func multilineSize(of text: UnsafePointer<CChar>, wrapLength: Int) -> CGSize {
         guard wrapLength > 0 else { return .zero }
-        let lineSpace = 2
+        let lineSpace = Int(lineSpacing)
 
         var textLineHeight: Int32 = 0
 
@@ -374,8 +374,6 @@ public class NSAttributedString {
     public init(string: String, attributes: [Key: Any] = [:]) {
         runs = [Run(text: string, font: attributes[.font] as? UIFont)]
     }
-
-    init(runs: [Run]) { self.runs = runs }
 }
 
 public final class NSMutableAttributedString: NSAttributedString {

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -134,15 +134,15 @@ public class FontRenderer {
         return CGImage(surface: surface)
     }
 
-    /// Returns `text` truncated with a trailing ellipsis so it fits within `maxWidth` (pixels).
-    /// Returns `text` unchanged when it already fits (or `maxWidth <= 0`).
-    func truncatedText(_ text: String, toWidth maxWidth: Int) -> String {
-        guard maxWidth > 0 else { return text }
+    /// Returns `text` truncated with a trailing ellipsis so it fits within `wrapLength` (pixels).
+    /// Returns `text` unchanged when it already fits (or `wrapLength <= 0`).
+    func truncatedText(_ text: String, wrapLength: Int) -> String {
+        guard wrapLength > 0 else { return text }
 
         var width: Int32 = 0
         var height: Int32 = 0
         TTF_SizeUTF8(rawPointer, text, &width, &height)
-        if Int(width) <= maxWidth { return text }
+        if Int(width) <= wrapLength { return text }
 
         let ellipsis = "…"
         var characters = Array(text)
@@ -150,7 +150,7 @@ public class FontRenderer {
             characters.removeLast()
             let candidate = String(characters) + ellipsis
             TTF_SizeUTF8(rawPointer, candidate, &width, &height)
-            if Int(width) <= maxWidth { return candidate }
+            if Int(width) <= wrapLength { return candidate }
         }
         return ellipsis
     }
@@ -200,12 +200,7 @@ public class FontRenderer {
 
             SDL_SetSurfaceBlendMode(surface, SDL_BLENDMODE_NONE)
             let lineWidth = surface.pointee.w
-            let x: Int32
-            switch alignment {
-            case .center: x = (Int32(wrapLength) - lineWidth) / 2
-            case .right: x = Int32(wrapLength) - lineWidth
-            case .left: x = 0
-            }
+            let x = alignmentStartX(surfaceWidth: Int32(wrapLength), contentWidth: lineWidth, alignment: alignment)
             var dstRect = SDLRect(x: max(0, x), y: Int32(index) * (lineHeight + lineSpacing), w: lineWidth, h: surface.pointee.h)
             SDL_UpperBlit(surface, nil, target, &dstRect)
         }
@@ -265,6 +260,15 @@ extension FontRenderer {
 }
 
 // Optimise perf
+/// Horizontal start offset for content of `contentWidth` within `surfaceWidth`, per `alignment`.
+private func alignmentStartX(surfaceWidth: Int32, contentWidth: Int32, alignment: NSTextAlignment) -> Int32 {
+    switch alignment {
+    case .center: return (surfaceWidth - contentWidth) / 2
+    case .right: return surfaceWidth - contentWidth
+    case .left: return 0
+    }
+}
+
 private let newLineR = Int32("\r".utf8.first!)
 private let newLineN = Int32("\n".utf8.first!)
 
@@ -347,19 +351,41 @@ extension FontRenderer {
     }
 }
 
-// MARK: Multi-font (styled-run) text
+// MARK: Attributed text
 
-/// Lightweight multi-font text: a sequence of (text, font) runs rendered inline with word
-/// wrapping and alignment. Fills the gap left by not having NSAttributedString in this polyfill,
-/// e.g. a bold label followed by a regular value on the same wrapping line.
+/// A minimal, Foundation-free stand-in for the slice of `NSAttributedString` we use: text split
+/// into runs that each carry a `.font`. Foundation (and thus the real type) isn't available on
+/// Android/Linux, so we define only the parts we implement, matching Apple's API shape — call
+/// sites are then identical on iOS (real UIKit) and here.
 @MainActor
-public struct StyledTextRun {
-    public let text: String
-    public let font: UIFont
+public class NSAttributedString {
+    public struct Key: Hashable {
+        public let rawValue: String
+        public init(rawValue: String) { self.rawValue = rawValue }
 
-    public init(_ text: String, font: UIFont) {
-        self.text = text
-        self.font = font
+        public static let font = Key(rawValue: "NSFont")
+    }
+
+    struct Run {
+        let text: String
+        let font: UIFont
+    }
+
+    var runs: [Run]
+    public var string: String { runs.map(\.text).joined() }
+
+    public init(string: String, attributes: [Key: Any] = [:]) {
+        let font = attributes[.font] as? UIFont ?? .systemFont(ofSize: 16)
+        runs = [Run(text: string, font: font)]
+    }
+
+    init(runs: [Run]) { self.runs = runs }
+}
+
+@MainActor
+public final class NSMutableAttributedString: NSAttributedString {
+    public func append(_ attributedString: NSAttributedString) {
+        runs.append(contentsOf: attributedString.runs)
     }
 }
 
@@ -375,10 +401,10 @@ extension FontRenderer {
 
     private static let styledLineSpacing: Int32 = 2
 
-    /// Splits runs into space-separated words, each tagged with its own font renderer/metrics.
-    private static func tokenize(_ runs: [StyledTextRun]) -> [WordToken] {
+    /// Splits an attributed string into space-separated words, each tagged with its run's font.
+    private static func tokenize(_ attributedString: NSAttributedString) -> [WordToken] {
         var tokens: [WordToken] = []
-        for run in runs {
+        for run in attributedString.runs {
             guard let renderer = run.font.fontRenderer else { continue }
 
             var spaceWidth: Int32 = 0
@@ -423,8 +449,8 @@ extension FontRenderer {
         }
     }
 
-    static func styledRunsSize(_ runs: [StyledTextRun], wrapLength: Int) -> CGSize {
-        let tokens = tokenize(runs)
+    static func attributedStringSize(_ attributedString: NSAttributedString, wrapLength: Int) -> CGSize {
+        let tokens = tokenize(attributedString)
         guard !tokens.isEmpty else { return .zero }
 
         let lineHeight = tokens.map { $0.height }.max() ?? 0
@@ -438,8 +464,8 @@ extension FontRenderer {
         return CGSize(width: wrapLength, height: height)
     }
 
-    static func renderStyledRuns(_ runs: [StyledTextRun], color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
-        let tokens = tokenize(runs)
+    static func renderAttributedString(_ attributedString: NSAttributedString, color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
+        let tokens = tokenize(attributedString)
         guard !tokens.isEmpty else { return nil }
 
         let lineHeight = tokens.map { $0.height }.max() ?? 0
@@ -454,12 +480,7 @@ extension FontRenderer {
         defer { SDL_FreeSurface(target) }
 
         for (lineIndex, line) in lines.enumerated() {
-            var x: Int32
-            switch alignment {
-            case .center: x = (surfaceWidth - lineWidth(line)) / 2
-            case .right: x = surfaceWidth - lineWidth(line)
-            case .left: x = 0
-            }
+            var x = alignmentStartX(surfaceWidth: surfaceWidth, contentWidth: lineWidth(line), alignment: alignment)
             let y = Int32(lineIndex) * (lineHeight + styledLineSpacing)
 
             for (index, token) in line.enumerated() {

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -352,7 +352,9 @@ extension FontRenderer {
     }
 }
 
-@MainActor
+// Not `@MainActor` — Foundation's `NSAttributedString` isn't isolated. The stored `UIFont` is only
+// *used* (via `fontRenderer`) in `tokenize`, which runs on the main actor; holding the reference here
+// needs no isolation. The default font is resolved lazily there to avoid a `@MainActor` call in init.
 public class NSAttributedString {
     public struct Key: Hashable {
         public let rawValue: String
@@ -363,21 +365,19 @@ public class NSAttributedString {
 
     struct Run {
         let text: String
-        let font: UIFont
+        let font: UIFont?
     }
 
     var runs: [Run]
     public var string: String { runs.map(\.text).joined() }
 
     public init(string: String, attributes: [Key: Any] = [:]) {
-        let font = attributes[.font] as? UIFont ?? .systemFont(ofSize: 16)
-        runs = [Run(text: string, font: font)]
+        runs = [Run(text: string, font: attributes[.font] as? UIFont)]
     }
 
     init(runs: [Run]) { self.runs = runs }
 }
 
-@MainActor
 public final class NSMutableAttributedString: NSAttributedString {
     public func append(_ attributedString: NSAttributedString) {
         runs.append(contentsOf: attributedString.runs)
@@ -395,10 +395,11 @@ extension FontRenderer {
     }
 
     /// Splits an attributed string into space-separated words, each tagged with its run's font.
-    private static func tokenize(_ attributedString: NSAttributedString) -> [WordToken] {
+    private static func tokenize(_ attributedString: NSAttributedString, defaultFont: UIFont) -> [WordToken] {
         var tokens: [WordToken] = []
         for run in attributedString.runs {
-            guard let renderer = run.font.fontRenderer else { continue }
+            let font = run.font ?? defaultFont
+            guard let renderer = font.fontRenderer else { continue }
 
             var spaceWidth: Int32 = 0
             var spaceHeight: Int32 = 0
@@ -444,8 +445,8 @@ extension FontRenderer {
 
     /// Tokenizes and wraps `attributedString` (wrapLength 0 = a single unwrapped line). Returns the
     /// laid-out lines, their shared height, and the resulting surface width — or nil if empty.
-    private static func layoutLines(_ attributedString: NSAttributedString, wrapLength: Int) -> (lines: [[WordToken]], lineHeight: Int32, width: Int32)? {
-        let tokens = tokenize(attributedString)
+    private static func layoutLines(_ attributedString: NSAttributedString, wrapLength: Int, defaultFont: UIFont) -> (lines: [[WordToken]], lineHeight: Int32, width: Int32)? {
+        let tokens = tokenize(attributedString, defaultFont: defaultFont)
         guard !tokens.isEmpty else { return nil }
 
         let lineHeight = tokens.map(\.height).max() ?? 0
@@ -458,13 +459,13 @@ extension FontRenderer {
         lineHeight * Int32(lineCount) + lineSpacing * Int32(max(0, lineCount - 1))
     }
 
-    static func getAttributedStringSize(_ attributedString: NSAttributedString, wrapLength: Int) -> CGSize {
-        guard let layout = layoutLines(attributedString, wrapLength: wrapLength) else { return .zero }
+    static func getAttributedStringSize(_ attributedString: NSAttributedString, wrapLength: Int, defaultFont: UIFont) -> CGSize {
+        guard let layout = layoutLines(attributedString, wrapLength: wrapLength, defaultFont: defaultFont) else { return .zero }
         return CGSize(width: Int(layout.width), height: Int(totalHeight(lineCount: layout.lines.count, lineHeight: layout.lineHeight)))
     }
 
-    static func renderAttributedString(_ attributedString: NSAttributedString, color: UIColor, wrapLength: Int, alignment: NSTextAlignment) -> CGImage? {
-        guard let layout = layoutLines(attributedString, wrapLength: wrapLength) else { return nil }
+    static func renderAttributedString(_ attributedString: NSAttributedString, color: UIColor, wrapLength: Int, alignment: NSTextAlignment, defaultFont: UIFont) -> CGImage? {
+        guard let layout = layoutLines(attributedString, wrapLength: wrapLength, defaultFont: defaultFont) else { return nil }
         let height = totalHeight(lineCount: layout.lines.count, lineHeight: layout.lineHeight)
 
         return composeImage(width: layout.width, height: height) { target in

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -136,7 +136,7 @@ public class FontRenderer {
 
     /// Returns `text` truncated with a trailing ellipsis so it fits within `wrapLength` (pixels).
     /// Returns `text` unchanged when it already fits (or `wrapLength <= 0`).
-    func truncatedText(_ text: String, wrapLength: Int) -> String {
+    func truncateTextIfNeeded(_ text: String, wrapLength: Int) -> String {
         guard wrapLength > 0 else { return text }
 
         var width: Int32 = 0

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -107,8 +107,10 @@ extension FragmentShader {
             float d = sdRoundedBox(absolutePixelPos - center, halfSize, r);
             float aa = max(fwidth(d), 1e-5) * 0.5;
 
-            float outer = 1.0 - smoothstep(-aa, aa, d);
-            float inner = 1.0 - smoothstep(-aa, aa, d + borderWidth);
+            // Antialias inward (the fade sits at d in [-2aa, 0], entirely inside the shape) so the
+            // edge never bleeds past the shape boundary and gets clipped by the draw quad.
+            float outer = 1.0 - smoothstep(-2.0 * aa, 0.0, d);
+            float inner = 1.0 - smoothstep(-2.0 * aa, 0.0, d + borderWidth);
             float alpha = outer - inner;
 
             \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -58,9 +58,12 @@ open class UIFont {
         return newlyLoadedRenderer
     }
 
-    internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0) -> CGImage? {
-        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale))
+    internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0, alignment: NSTextAlignment = .left) -> CGImage? {
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale), alignment: alignment)
     }
+
+    /// The rendering backend for this font, exposed for multi-font (styled-run) rendering.
+    internal var fontRenderer: FontRenderer? { renderer }
 }
 
 // MARK: Caches

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -6,7 +6,7 @@ open class UIFont {
     }
     public var pointSize: CGFloat
     public var lineHeight: CGFloat {
-        return CGFloat(renderer?.getLineHeight() ?? 0) / (UIScreen.main?.scale ?? 2)
+        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.lastKnownScreenScale
     }
 
     /**
@@ -27,7 +27,7 @@ open class UIFont {
 
     public init?(name: String, size: CGFloat) {
         let name = name.lowercased()
-        let size = Int32(size * (UIScreen.main?.scale ?? 2))
+        let size = Int32(size * UIScreen.lastKnownScreenScale)
 
         self.fontName = name
         self.pointSize = CGFloat(size)
@@ -59,7 +59,7 @@ open class UIFont {
     }
 
     internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0, alignment: NSTextAlignment = .left) -> CGImage? {
-        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * (UIScreen.main?.scale ?? 2)), alignment: alignment)
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.lastKnownScreenScale), alignment: alignment)
     }
 
     /// The rendering backend for this font, exposed for multi-font (styled-run) rendering.

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -6,7 +6,7 @@ open class UIFont {
     }
     public var pointSize: CGFloat
     public var lineHeight: CGFloat {
-        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.lastKnownScreenScale
+        return CGFloat(renderer?.getLineHeight() ?? 0) / (UIScreen.lastKnownScreenScale ?? 2)
     }
 
     /**
@@ -27,7 +27,7 @@ open class UIFont {
 
     public init?(name: String, size: CGFloat) {
         let name = name.lowercased()
-        let size = Int32(size * UIScreen.lastKnownScreenScale)
+        let size = Int32(size * (UIScreen.lastKnownScreenScale ?? 2))
 
         self.fontName = name
         self.pointSize = CGFloat(size)
@@ -59,7 +59,7 @@ open class UIFont {
     }
 
     internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0, alignment: NSTextAlignment = .left) -> CGImage? {
-        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.lastKnownScreenScale), alignment: alignment)
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * (UIScreen.lastKnownScreenScale ?? 2)), alignment: alignment)
     }
 
     /// The rendering backend for this font, exposed for multi-font (styled-run) rendering.

--- a/Sources/UIFont.swift
+++ b/Sources/UIFont.swift
@@ -6,7 +6,7 @@ open class UIFont {
     }
     public var pointSize: CGFloat
     public var lineHeight: CGFloat {
-        return CGFloat(renderer?.getLineHeight() ?? 0) / UIScreen.main.scale
+        return CGFloat(renderer?.getLineHeight() ?? 0) / (UIScreen.main?.scale ?? 2)
     }
 
     /**
@@ -59,7 +59,7 @@ open class UIFont {
     }
 
     internal func render(_ text: String?, color: UIColor, wrapLength: CGFloat = 0, alignment: NSTextAlignment = .left) -> CGImage? {
-        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * UIScreen.main.scale), alignment: alignment)
+        return renderer?.render(text, color: color, wrapLength: Int(wrapLength * (UIScreen.main?.scale ?? 2)), alignment: alignment)
     }
 
     /// The rendering backend for this font, exposed for multi-font (styled-run) rendering.

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -21,8 +21,6 @@ public enum NSTextAlignment: Int {
 }
 
 public enum NSLineBreakMode: Int {
-    // Only the modes the polyfill actually implements are declared — using an unsupported mode
-    // should be a compile error, not a silent no-op. Add cases here as they gain real support.
     case byTruncatingTail
 }
 
@@ -50,7 +48,6 @@ open class UILabel: UIView {
         didSet { updateLayerContentsGravityFromTextAlignment() }
     }
 
-    /// Matches UIKit's default: single-line labels get a trailing ellipsis to fit their width.
     open var lineBreakMode: NSLineBreakMode = .byTruncatingTail {
         didSet { if lineBreakMode != oldValue { setNeedsDisplay() } }
     }
@@ -67,17 +64,21 @@ open class UILabel: UIView {
         didSet { if oldValue.size != frame.size { setNeedsDisplay() } }
     }
 
+    /// Wrap width in device pixels for the attributed-text path (0 = single line = no wrapping).
+    private var attributedWrapLength: Int {
+        Int((numberOfLines != 1 ? bounds.width : 0) * (UIScreen.main?.scale ?? 2))
+    }
+
     open override func draw() {
         super.draw()
         if let attributedText = attributedText {
-            let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
-            layer.contents = FontRenderer.renderAttributedString(attributedText, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
+            layer.contents = FontRenderer.renderAttributedString(attributedText, color: textColor, wrapLength: attributedWrapLength, alignment: textAlignment)
             return
         }
         // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
         // UIKit's default behaviour instead of overflowing/clipping.
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncatedText(text, wrapLength: Int(bounds.width * UIScreen.main.scale))
+            let truncated = renderer.truncatedText(text, wrapLength: Int(bounds.width * (UIScreen.main?.scale ?? 2)))
             layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
             return
         }
@@ -98,8 +99,7 @@ open class UILabel: UIView {
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         if let attributedText = attributedText {
-            let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
-            return FontRenderer.attributedStringSize(attributedText, wrapLength: wrapLength) / UIScreen.main.scale
+            return FontRenderer.getAttributedStringSize(attributedText, wrapLength: attributedWrapLength) / (UIScreen.main?.scale ?? 2)
         }
 
         guard let text = self.text else { return .zero }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -78,7 +78,7 @@ open class UILabel: UIView {
         // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
         // UIKit's default behaviour instead of overflowing/clipping.
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncatedText(text, wrapLength: Int(bounds.width * (UIScreen.main?.scale ?? 2)))
+            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.main?.scale ?? 2)))
             layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
             return
         }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -30,6 +30,12 @@ open class UILabel: UIView {
         didSet { if text != oldValue { setNeedsDisplay() } }
     }
 
+    /// Multi-font inline text (e.g. a bold label + regular value). When set, takes precedence
+    /// over `text`/`font` for both sizing and drawing.
+    open var styledRuns: [StyledTextRun]? {
+        didSet { setNeedsDisplay() }
+    }
+
     open var textColor: UIColor = .black {
         didSet { if textColor != oldValue { setNeedsDisplay() } }
     }
@@ -52,8 +58,21 @@ open class UILabel: UIView {
 
     open override func draw() {
         super.draw()
+        if let styledRuns = styledRuns {
+            let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
+            layer.contents = FontRenderer.renderStyledRuns(styledRuns, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
+            return
+        }
+        // Single-line labels truncate with a trailing ellipsis to fit their width (like iOS'
+        // default `.byTruncatingTail`), instead of overflowing/clipping.
+        if numberOfLines == 1, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
+            let truncated = renderer.truncatedText(text, toWidth: Int(bounds.width * UIScreen.main.scale))
+            layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
+            return
+        }
+
         let wrapLength = (numberOfLines != 1) ? bounds.width : 0
-        layer.contents = font.render(text, color: textColor, wrapLength: wrapLength)
+        layer.contents = font.render(text, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
     }
 
     override open func display(_ layer: CALayer) {
@@ -67,6 +86,11 @@ open class UILabel: UIView {
     }
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
+        if let styledRuns = styledRuns {
+            let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
+            return FontRenderer.styledRunsSize(styledRuns, wrapLength: wrapLength) / UIScreen.main.scale
+        }
+
         guard let text = self.text else { return .zero }
         let wrapLength = (numberOfLines != 1) ? bounds.width : 0
 

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -20,6 +20,12 @@ public enum NSTextAlignment: Int {
     }
 }
 
+public enum NSLineBreakMode: Int {
+    // Only the modes the polyfill actually implements are declared — using an unsupported mode
+    // should be a compile error, not a silent no-op. Add cases here as they gain real support.
+    case byTruncatingTail
+}
+
 @MainActor
 open class UILabel: UIView {
     open var numberOfLines: Int = 1 {
@@ -31,8 +37,8 @@ open class UILabel: UIView {
     }
 
     /// Multi-font inline text (e.g. a bold label + regular value). When set, takes precedence
-    /// over `text`/`font` for both sizing and drawing.
-    open var styledRuns: [StyledTextRun]? {
+    /// over `text`/`font` for both sizing and drawing. Only the `.font` attribute is honoured.
+    open var attributedText: NSAttributedString? {
         didSet { setNeedsDisplay() }
     }
 
@@ -42,6 +48,11 @@ open class UILabel: UIView {
 
     open var textAlignment: NSTextAlignment = .left {
         didSet { updateLayerContentsGravityFromTextAlignment() }
+    }
+
+    /// Matches UIKit's default: single-line labels get a trailing ellipsis to fit their width.
+    open var lineBreakMode: NSLineBreakMode = .byTruncatingTail {
+        didSet { if lineBreakMode != oldValue { setNeedsDisplay() } }
     }
 
     private func updateLayerContentsGravityFromTextAlignment() {
@@ -58,15 +69,15 @@ open class UILabel: UIView {
 
     open override func draw() {
         super.draw()
-        if let styledRuns = styledRuns {
+        if let attributedText = attributedText {
             let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
-            layer.contents = FontRenderer.renderStyledRuns(styledRuns, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
+            layer.contents = FontRenderer.renderAttributedString(attributedText, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
             return
         }
-        // Single-line labels truncate with a trailing ellipsis to fit their width (like iOS'
-        // default `.byTruncatingTail`), instead of overflowing/clipping.
-        if numberOfLines == 1, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncatedText(text, toWidth: Int(bounds.width * UIScreen.main.scale))
+        // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
+        // UIKit's default behaviour instead of overflowing/clipping.
+        if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
+            let truncated = renderer.truncatedText(text, wrapLength: Int(bounds.width * UIScreen.main.scale))
             layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
             return
         }
@@ -86,9 +97,9 @@ open class UILabel: UIView {
     }
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
-        if let styledRuns = styledRuns {
+        if let attributedText = attributedText {
             let wrapLength = Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.main.scale)
-            return FontRenderer.styledRunsSize(styledRuns, wrapLength: wrapLength) / UIScreen.main.scale
+            return FontRenderer.attributedStringSize(attributedText, wrapLength: wrapLength) / UIScreen.main.scale
         }
 
         guard let text = self.text else { return .zero }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -66,7 +66,7 @@ open class UILabel: UIView {
 
     /// Wrap width in device pixels for the attributed-text path (0 = single line = no wrapping).
     private var attributedWrapLength: Int {
-        Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.lastKnownScreenScale)
+        Int((numberOfLines != 1 ? bounds.width : 0) * (UIScreen.lastKnownScreenScale ?? 2))
     }
 
     open override func draw() {
@@ -78,7 +78,7 @@ open class UILabel: UIView {
         // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
         // UIKit's default behaviour instead of overflowing/clipping.
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * UIScreen.lastKnownScreenScale))
+            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.lastKnownScreenScale ?? 2)))
             layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
             return
         }
@@ -99,7 +99,7 @@ open class UILabel: UIView {
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         if let attributedText = attributedText {
-            return FontRenderer.getAttributedStringSize(attributedText, wrapLength: attributedWrapLength, defaultFont: font) / UIScreen.lastKnownScreenScale
+            return FontRenderer.getAttributedStringSize(attributedText, wrapLength: attributedWrapLength, defaultFont: font) / (UIScreen.lastKnownScreenScale ?? 2)
         }
 
         guard let text = self.text else { return .zero }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -66,19 +66,19 @@ open class UILabel: UIView {
 
     /// Wrap width in device pixels for the attributed-text path (0 = single line = no wrapping).
     private var attributedWrapLength: Int {
-        Int((numberOfLines != 1 ? bounds.width : 0) * (UIScreen.main?.scale ?? 2))
+        Int((numberOfLines != 1 ? bounds.width : 0) * UIScreen.lastKnownScreenScale)
     }
 
     open override func draw() {
         super.draw()
         if let attributedText = attributedText {
-            layer.contents = FontRenderer.renderAttributedString(attributedText, color: textColor, wrapLength: attributedWrapLength, alignment: textAlignment)
+            layer.contents = FontRenderer.renderAttributedString(attributedText, color: textColor, wrapLength: attributedWrapLength, alignment: textAlignment, defaultFont: font)
             return
         }
         // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
         // UIKit's default behaviour instead of overflowing/clipping.
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.main?.scale ?? 2)))
+            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * UIScreen.lastKnownScreenScale))
             layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
             return
         }
@@ -99,7 +99,7 @@ open class UILabel: UIView {
 
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         if let attributedText = attributedText {
-            return FontRenderer.getAttributedStringSize(attributedText, wrapLength: attributedWrapLength) / (UIScreen.main?.scale ?? 2)
+            return FontRenderer.getAttributedStringSize(attributedText, wrapLength: attributedWrapLength, defaultFont: font) / UIScreen.lastKnownScreenScale
         }
 
         guard let text = self.text else { return .zero }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -77,14 +77,13 @@ open class UILabel: UIView {
         }
         // Single-line, tail-truncating labels get a trailing ellipsis to fit their width, matching
         // UIKit's default behaviour instead of overflowing/clipping.
+        var textToRender = text
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            let truncated = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.lastKnownScreenScale ?? 2)))
-            layer.contents = font.render(truncated, color: textColor, wrapLength: 0, alignment: textAlignment)
-            return
+            textToRender = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.lastKnownScreenScale ?? 2)))
         }
 
         let wrapLength = (numberOfLines != 1) ? bounds.width : 0
-        layer.contents = font.render(text, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
+        layer.contents = font.render(textToRender, color: textColor, wrapLength: wrapLength, alignment: textAlignment)
     }
 
     override open func display(_ layer: CALayer) {

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -87,7 +87,10 @@ extension UIScreen {
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
             ShaderProgram.roundedRect.setFill(rect: rect, cornerRadius: cornerRadius)
-            GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
+            // Draw into a quad 1px larger on every side so the SDF's antialiased edge isn't
+            // clipped at the shape's cardinal points (most visible on perfect circles). The
+            // extra ring is effectively zero-alpha for the shape itself.
+            GPU_RectangleFilled(rawPointer, gpuRect(rect.insetBy(dx: -1, dy: -1)), color: color.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -87,10 +87,7 @@ extension UIScreen {
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
             ShaderProgram.roundedRect.setFill(rect: rect, cornerRadius: cornerRadius)
-            // Draw into a quad 1px larger on every side so the SDF's antialiased edge isn't
-            // clipped at the shape's cardinal points (most visible on perfect circles). The
-            // extra ring is effectively zero-alpha for the shape itself.
-            GPU_RectangleFilled(rawPointer, gpuRect(rect.insetBy(dx: -1, dy: -1)), color: color.sdlColor)
+            GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -16,7 +16,9 @@ public extension UIScreen {
     internal(set) static var main: UIScreen! {
         didSet {
             CALayer.layerTreeIsDirty = true
-            if let scale = main?.scale { lastKnownScreenScale = scale }
+            if let scale = main?.scale {
+                lastKnownScreenScale = scale
+            }
         }
     }
 

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -234,7 +234,9 @@ extension CGSize {
     nonisolated static let samsungGalaxyS5 = CGSize(width: 1920 / 3.0, height: 1080 / 3.0)
     nonisolated static let samsungGalaxyS7 = CGSize(width: 2560 / 4.0, height: 1440 / 4.0) // 1080p 1.5x Retina
     nonisolated static let samsungGalaxyS8 = CGSize(width: 2960 / 4.0, height: 1440 / 4.0)
-    nonisolated static let pixel7Pro = CGSize(width: 3120 / 3.5, height: 1440 / 3.5)
+    // Roughly the Pixel 7 Pro logical viewport, but as clean 8-aligned integers: a fractional/odd
+    // render-target width misaligns the video texture pitch (diagonal-stripe artefacts).
+    nonisolated static let pixel7Pro = CGSize(width: 896, height: 416)
 
     // tablets:
     nonisolated static let nexus9 = CGSize(width: 2048 / 2.0, height: 1536 / 2.0)

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -16,6 +16,11 @@ public extension UIScreen {
     internal(set) static var main: UIScreen! {
         didSet { CALayer.layerTreeIsDirty = true }
     }
+
+    /// The scale of the most recently initialized screen, used as the fallback when there is no
+    /// active `UIScreen.main` (e.g. during teardown/reinit). Defaults to 2 before any screen exists.
+    @MainActor
+    internal(set) static var lastKnownScreenScale: CGFloat = 2
 }
 
 @MainActor
@@ -38,6 +43,7 @@ public final class UIScreen {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
+        UIScreen.lastKnownScreenScale = scale
     }
 
     convenience init() {

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -58,7 +58,7 @@ public final class UIScreen {
         var size = CGSize.zero
         let options: SDLWindowFlags = SDL_WINDOW_FULLSCREEN
         #else
-        var size = CGSize.samsungGalaxyJ5.landscape
+        var size = CGSize.pixel7Pro.landscape
 
         let options: SDLWindowFlags = [
             SDL_WINDOW_ALLOW_HIGHDPI,
@@ -234,6 +234,7 @@ extension CGSize {
     nonisolated static let samsungGalaxyS5 = CGSize(width: 1920 / 3.0, height: 1080 / 3.0)
     nonisolated static let samsungGalaxyS7 = CGSize(width: 2560 / 4.0, height: 1440 / 4.0) // 1080p 1.5x Retina
     nonisolated static let samsungGalaxyS8 = CGSize(width: 2960 / 4.0, height: 1440 / 4.0)
+    nonisolated static let pixel7Pro = CGSize(width: 3120 / 3.5, height: 1440 / 3.5)
 
     // tablets:
     nonisolated static let nexus9 = CGSize(width: 2048 / 2.0, height: 1536 / 2.0)

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -14,13 +14,16 @@ extension SDLWindowFlags: @retroactive OptionSet {}
 public extension UIScreen {
     @MainActor
     internal(set) static var main: UIScreen! {
-        didSet { CALayer.layerTreeIsDirty = true }
+        didSet {
+            CALayer.layerTreeIsDirty = true
+            if let scale = main?.scale { lastKnownScreenScale = scale }
+        }
     }
 
-    /// The scale of the most recently initialized screen, used as the fallback when there is no
-    /// active `UIScreen.main` (e.g. during teardown/reinit). Defaults to 2 before any screen exists.
+    /// The last active screen's scale, kept so callers can fall back to it while `UIScreen.main` is
+    /// briefly nil (teardown/reinit). `nil` only before any screen has ever existed.
     @MainActor
-    internal(set) static var lastKnownScreenScale: CGFloat = 2
+    internal(set) static var lastKnownScreenScale: CGFloat?
 }
 
 @MainActor
@@ -43,7 +46,6 @@ public final class UIScreen {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
-        UIScreen.lastKnownScreenScale = scale
     }
 
     convenience init() {

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -135,7 +135,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     public init(frame: CGRect) {
         self.layer = type(of: self).layerClass.init()
-        self.layer.contentsScale = UIScreen.lastKnownScreenScale
+        self.layer.contentsScale = UIScreen.lastKnownScreenScale ?? 2
         super.init()
 
         self.layer.delegate = self

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -135,7 +135,7 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
 
     public init(frame: CGRect) {
         self.layer = type(of: self).layerClass.init()
-        self.layer.contentsScale = UIScreen.main?.scale ?? 2
+        self.layer.contentsScale = UIScreen.lastKnownScreenScale
         super.init()
 
         self.layer.delegate = self

--- a/UIKitTests/UIFontTests.swift
+++ b/UIKitTests/UIFontTests.swift
@@ -7,6 +7,9 @@
 //
 
 import XCTest
+#if !os(iOS)
+@testable import UIKit // access the polyfill's internal text-rendering helpers
+#endif
 
 @MainActor
 class UIFontTests: XCTestCase {
@@ -50,3 +53,88 @@ private extension String {
         return self.reduce(1, { total, char in total + ((char == "\n") ? 1 : 0) })
     }
 }
+
+#if !os(iOS)
+/// Tests for the text-rendering helpers this UIKit polyfill adds on top of SDL_ttf:
+/// single-line ellipsis truncation, greedy word wrapping, and attributed (multi-font) text.
+/// These only exercise measurement (`TTF_SizeUTF8`), so they need no GPU/render target.
+@MainActor
+class TextRenderingTests: XCTestCase {
+    // The font is loaded by TestSetup; `fontRenderer` is the SDL_ttf backend used for measuring.
+    private var renderer: FontRenderer { UIFont.systemFont(ofSize: 16).fontRenderer! }
+
+    // MARK: Truncation (numberOfLines == 1 + .byTruncatingTail)
+
+    func testTruncatedTextIsUnchangedWhenItFits() {
+        let text = "Short"
+        let wideEnough = Int(renderer.singleLineSize(of: text).width) + 100
+        XCTAssertEqual(renderer.truncatedText(text, wrapLength: wideEnough), text)
+    }
+
+    func testTruncatedTextAddsEllipsisAndFitsWithinWidth() {
+        let text = "A line long enough that it must be truncated to fit"
+        let half = Int(renderer.singleLineSize(of: text).width / 2)
+
+        let result = renderer.truncatedText(text, wrapLength: half)
+        XCTAssertNotEqual(result, text)
+        XCTAssertTrue(result.hasSuffix("…"))
+        XCTAssertLessThanOrEqual(Int(renderer.singleLineSize(of: result).width), half)
+    }
+
+    func testTruncatedTextReturnsInputForNonPositiveWidth() {
+        XCTAssertEqual(renderer.truncatedText("Hello", wrapLength: 0), "Hello")
+    }
+
+    // MARK: Word wrapping
+
+    func testWrapLinesKeepsTextOnOneLineWhenItFits() {
+        let text = "one two three"
+        let wideEnough = Int(renderer.singleLineSize(of: text).width) + 100
+        XCTAssertEqual(renderer.wrapLines(of: text, wrapLength: wideEnough), [text])
+    }
+
+    func testWrapLinesBreaksLongTextAcrossLinesKeepingEveryWord() {
+        let text = "one two three four five six seven eight nine ten"
+        let narrow = Int(renderer.singleLineSize(of: "one two three").width)
+
+        let lines = renderer.wrapLines(of: text, wrapLength: narrow)
+        XCTAssertGreaterThan(lines.count, 1)
+        // Greedy word wrapping never drops or reorders words.
+        XCTAssertEqual(lines.joined(separator: " "), text)
+    }
+
+    func testWrapLinesHonoursExplicitNewlines() {
+        XCTAssertEqual(renderer.wrapLines(of: "first\nsecond\nthird", wrapLength: 10_000), ["first", "second", "third"])
+    }
+
+    // MARK: Attributed (multi-font) text
+
+    func testMutableAttributedStringConcatenatesRuns() {
+        let string = NSMutableAttributedString(string: "Composer: ", attributes: [.font: UIFont.boldSystemFont(ofSize: 16)])
+        string.append(NSAttributedString(string: "J. S. Bach", attributes: [.font: UIFont.systemFont(ofSize: 16)]))
+        XCTAssertEqual(string.string, "Composer: J. S. Bach")
+    }
+
+    func testAttributedStringSizeHasPositiveDimensions() {
+        let string = NSAttributedString(string: "Hello world", attributes: [.font: UIFont.systemFont(ofSize: 16)])
+        let size = FontRenderer.getAttributedStringSize(string, wrapLength: 0)
+        XCTAssertGreaterThan(size.width, 0)
+        XCTAssertGreaterThan(size.height, 0)
+    }
+
+    func testAttributedStringSizeWrapsToWrapLengthAndGrowsTaller() {
+        let string = NSAttributedString(string: "one two three four five six seven eight", attributes: [.font: UIFont.systemFont(ofSize: 16)])
+        let unwrapped = FontRenderer.getAttributedStringSize(string, wrapLength: 0)
+        let wrapLength = Int(unwrapped.width / 3)
+
+        let wrapped = FontRenderer.getAttributedStringSize(string, wrapLength: wrapLength)
+        XCTAssertEqual(wrapped.width, CGFloat(wrapLength))
+        XCTAssertGreaterThan(wrapped.height, unwrapped.height)
+    }
+
+    func testEmptyAttributedStringHasZeroSize() {
+        let string = NSAttributedString(string: "", attributes: [.font: UIFont.systemFont(ofSize: 16)])
+        XCTAssertEqual(FontRenderer.getAttributedStringSize(string, wrapLength: 0), .zero)
+    }
+}
+#endif

--- a/UIKitTests/UIFontTests.swift
+++ b/UIKitTests/UIFontTests.swift
@@ -117,24 +117,24 @@ class TextRenderingTests: XCTestCase {
 
     func testAttributedStringSizeHasPositiveDimensions() {
         let string = NSAttributedString(string: "Hello world", attributes: [.font: UIFont.systemFont(ofSize: 16)])
-        let size = FontRenderer.getAttributedStringSize(string, wrapLength: 0)
+        let size = FontRenderer.getAttributedStringSize(string, wrapLength: 0, defaultFont: .systemFont(ofSize: 16))
         XCTAssertGreaterThan(size.width, 0)
         XCTAssertGreaterThan(size.height, 0)
     }
 
     func testAttributedStringSizeWrapsToWrapLengthAndGrowsTaller() {
         let string = NSAttributedString(string: "one two three four five six seven eight", attributes: [.font: UIFont.systemFont(ofSize: 16)])
-        let unwrapped = FontRenderer.getAttributedStringSize(string, wrapLength: 0)
+        let unwrapped = FontRenderer.getAttributedStringSize(string, wrapLength: 0, defaultFont: .systemFont(ofSize: 16))
         let wrapLength = Int(unwrapped.width / 3)
 
-        let wrapped = FontRenderer.getAttributedStringSize(string, wrapLength: wrapLength)
+        let wrapped = FontRenderer.getAttributedStringSize(string, wrapLength: wrapLength, defaultFont: .systemFont(ofSize: 16))
         XCTAssertEqual(wrapped.width, CGFloat(wrapLength))
         XCTAssertGreaterThan(wrapped.height, unwrapped.height)
     }
 
     func testEmptyAttributedStringHasZeroSize() {
         let string = NSAttributedString(string: "", attributes: [.font: UIFont.systemFont(ofSize: 16)])
-        XCTAssertEqual(FontRenderer.getAttributedStringSize(string, wrapLength: 0), .zero)
+        XCTAssertEqual(FontRenderer.getAttributedStringSize(string, wrapLength: 0, defaultFont: .systemFont(ofSize: 16)), .zero)
     }
 }
 #endif

--- a/UIKitTests/UIFontTests.swift
+++ b/UIKitTests/UIFontTests.swift
@@ -68,21 +68,21 @@ class TextRenderingTests: XCTestCase {
     func testTruncatedTextIsUnchangedWhenItFits() {
         let text = "Short"
         let wideEnough = Int(renderer.singleLineSize(of: text).width) + 100
-        XCTAssertEqual(renderer.truncatedText(text, wrapLength: wideEnough), text)
+        XCTAssertEqual(renderer.truncateTextIfNeeded(text, wrapLength: wideEnough), text)
     }
 
     func testTruncatedTextAddsEllipsisAndFitsWithinWidth() {
         let text = "A line long enough that it must be truncated to fit"
         let half = Int(renderer.singleLineSize(of: text).width / 2)
 
-        let result = renderer.truncatedText(text, wrapLength: half)
+        let result = renderer.truncateTextIfNeeded(text, wrapLength: half)
         XCTAssertNotEqual(result, text)
         XCTAssertTrue(result.hasSuffix("…"))
         XCTAssertLessThanOrEqual(Int(renderer.singleLineSize(of: result).width), half)
     }
 
     func testTruncatedTextReturnsInputForNonPositiveWidth() {
-        XCTAssertEqual(renderer.truncatedText("Hello", wrapLength: 0), "Hello")
+        XCTAssertEqual(renderer.truncateTextIfNeeded("Hello", wrapLength: 0), "Hello")
     }
 
     // MARK: Word wrapping


### PR DESCRIPTION
**Type of change:** feature

## Motivation (current vs expected behavior)
- Fix rounding for close button
- Allow center alignment of multiline text
- Implement `lineBreakMode byTruncatingTail` 
- Implement attributed text to allow rendering multiple fonts in one label text 


(p.s. The headline is repeated 2x in the screenshot to demonstrate the line truncation)
<img width="891" height="443" alt="Screenshot 2026-07-02 at 09 42 51" src="https://github.com/user-attachments/assets/e9dcb730-8598-43d4-a196-7973e170d532" />


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
