### PR TITLE
fix button label truncation

### DIFF
--- a/Sources/Button.swift
+++ b/Sources/Button.swift
@@ -141,6 +141,13 @@ open class Button: UIControl {
 
         titleLabel.setNeedsLayout()
 
+        // Size the title to its current text/font (as UIButton does) so its bounds match what's
+        // rendered — otherwise a label sized in another weight is a hair too narrow and our
+        // tail-truncation crops it. Hugs the text, so centered titles don't shift.
+        if titleLabelIsVisible {
+            titleLabel.sizeToFit()
+        }
+
         let imageWidth = imageView.frame.width
         let labelWidth = titleLabel.frame.width
 

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -136,19 +136,20 @@ public class FontRenderer {
 
     /// Returns `text` truncated with a trailing ellipsis so it fits within `wrapLength` (pixels).
     /// Returns `text` unchanged when it already fits (or `wrapLength <= 0`).
-    func truncateTextIfNeeded(_ text: String, wrapLength: Int) -> String {
+    func truncateTextIfNeeded(_ text: String, wrapLength: CGFloat) -> String {
         guard wrapLength > 0 else { return text }
 
-        // Measure with `size(_:)`, the same ruler that sized the label. `TTF_SizeUTF8` measures
-        // subtly differently, so a label sized to just fit could still be truncated here.
-        if Int(size(text).width) <= wrapLength { return text }
+        // Measure with `size(_:)`, the same ruler that sized the label; `TTF_SizeUTF8` measures
+        // subtly differently, so a label sized to just fit could still be truncated here. `wrapLength`
+        // is the available width in whole device pixels (the caller rounds up), so a fit compares cleanly.
+        if CGFloat(size(text).width) <= wrapLength { return text }
 
         let ellipsis = "…"
         var characters = Array(text)
         while !characters.isEmpty {
             characters.removeLast()
             let candidate = String(characters) + ellipsis
-            if Int(size(candidate).width) <= wrapLength { return candidate }
+            if CGFloat(size(candidate).width) <= wrapLength { return candidate }
         }
         return ellipsis
     }

--- a/Sources/FontRenderer.swift
+++ b/Sources/FontRenderer.swift
@@ -139,18 +139,16 @@ public class FontRenderer {
     func truncateTextIfNeeded(_ text: String, wrapLength: Int) -> String {
         guard wrapLength > 0 else { return text }
 
-        var width: Int32 = 0
-        var height: Int32 = 0
-        TTF_SizeUTF8(rawPointer, text, &width, &height)
-        if Int(width) <= wrapLength { return text }
+        // Measure with `size(_:)`, the same ruler that sized the label. `TTF_SizeUTF8` measures
+        // subtly differently, so a label sized to just fit could still be truncated here.
+        if Int(size(text).width) <= wrapLength { return text }
 
         let ellipsis = "…"
         var characters = Array(text)
         while !characters.isEmpty {
             characters.removeLast()
             let candidate = String(characters) + ellipsis
-            TTF_SizeUTF8(rawPointer, candidate, &width, &height)
-            if Int(width) <= wrapLength { return candidate }
+            if Int(size(candidate).width) <= wrapLength { return candidate }
         }
         return ellipsis
     }

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -79,7 +79,10 @@ open class UILabel: UIView {
         // UIKit's default behaviour instead of overflowing/clipping.
         var textToRender = text
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            textToRender = renderer.truncateTextIfNeeded(text, wrapLength: Int(bounds.width * (UIScreen.lastKnownScreenScale ?? 2)))
+            // Round (not floor) points→pixels: width is pixels ÷ scale, so on a fractional scale
+            // `width * scale` can land a hair low and flooring would clip text that fits.
+            let availableWidthInPixels = Int((bounds.width * (UIScreen.lastKnownScreenScale ?? 2)).rounded())
+            textToRender = renderer.truncateTextIfNeeded(text, wrapLength: availableWidthInPixels)
         }
 
         let wrapLength = (numberOfLines != 1) ? bounds.width : 0

--- a/Sources/UILabel.swift
+++ b/Sources/UILabel.swift
@@ -79,9 +79,11 @@ open class UILabel: UIView {
         // UIKit's default behaviour instead of overflowing/clipping.
         var textToRender = text
         if numberOfLines == 1, lineBreakMode == .byTruncatingTail, let text = text, bounds.width > 0, let renderer = font.fontRenderer {
-            // Round (not floor) points→pixels: width is pixels ÷ scale, so on a fractional scale
-            // `width * scale` can land a hair low and flooring would clip text that fits.
-            let availableWidthInPixels = Int((bounds.width * (UIScreen.lastKnownScreenScale ?? 2)).rounded())
+            // Available width in device pixels, rounded up to a whole pixel. A label sized to exactly
+            // fit stores its width as `textPixels / scale`; multiplying back by scale can land a hair
+            // below `textPixels` at fractional scales, so rounding up recovers the whole pixel and text
+            // that fits isn't clipped.
+            let availableWidthInPixels = (bounds.width * (UIScreen.lastKnownScreenScale ?? 2)).rounded(.up)
             textToRender = renderer.truncateTextIfNeeded(text, wrapLength: availableWidthInPixels)
         }
 

--- a/UIKitTests/UIFontTests.swift
+++ b/UIKitTests/UIFontTests.swift
@@ -67,18 +67,18 @@ class TextRenderingTests: XCTestCase {
 
     func testTruncatedTextIsUnchangedWhenItFits() {
         let text = "Short"
-        let wideEnough = Int(renderer.singleLineSize(of: text).width) + 100
+        let wideEnough = renderer.singleLineSize(of: text).width + 100
         XCTAssertEqual(renderer.truncateTextIfNeeded(text, wrapLength: wideEnough), text)
     }
 
     func testTruncatedTextAddsEllipsisAndFitsWithinWidth() {
         let text = "A line long enough that it must be truncated to fit"
-        let half = Int(renderer.singleLineSize(of: text).width / 2)
+        let half = renderer.singleLineSize(of: text).width / 2
 
         let result = renderer.truncateTextIfNeeded(text, wrapLength: half)
         XCTAssertNotEqual(result, text)
         XCTAssertTrue(result.hasSuffix("…"))
-        XCTAssertLessThanOrEqual(Int(renderer.singleLineSize(of: result).width), half)
+        XCTAssertLessThanOrEqual(renderer.singleLineSize(of: result).width, half)
     }
 
     func testTruncatedTextReturnsInputForNonPositiveWidth() {


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)

**Issue:** a single-line `Button` title (or a `UILabel` laid out inside a button) was truncated with a trailing ellipsis even when its bounds were wide enough for the text. Expected: the full title shows, and the ellipsis only appears when the text genuinely doesn't fit.

**Cause:** the custom tail-truncation decided to truncate against a slightly different width than the one used to *size* the label, so a label sized to *just* fit read as overflowing by a pixel or two. Three small inconsistencies compounded it:

- the label was sized in one font weight (e.g. a caller reserving the bold/selected-state width) but rendered in another;
- `truncateTextIfNeeded` measured with `TTF_SizeUTF8`, a different ruler than the `size(_:)` used to size the label;
- the points→pixels conversion floored instead of rounded, dropping a sub-pixel on fractional screen scales (e.g. ~2.63x).

UIKit on iOS never shows this because `UIButton`/`UILabel` size and truncate through one consistent engine. This PR brings the cross-platform implementation in line: `Button` now sizes its title label to its current text/font each layout pass (as `UIButton` does), `truncateTextIfNeeded` measures with the same `size(_:)` ruler used for sizing, and the pixel conversion rounds instead of flooring. Net: labels show in full when they fit, and the ellipsis appears only on genuine overflow.

<img width="2340" height="1080" alt="2026-07-08_20 40 27" src="https://github.com/user-attachments/assets/6fcf320b-c165-4604-9e95-3a84fd7954b7" />

<img width="2340" height="1080" alt="2026-07-08_20 40 25" src="https://github.com/user-attachments/assets/fc3d59ec-23cb-45c4-9070-f10ee320a13b" />

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
