### PR TITLE
fix pixel snapping

### DIFF
--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -43,8 +43,19 @@ extension CALayer {
 
         self.hasBeenRenderedInThisPartOfOverallLayerHierarchy = true
 
-        // We only actually set the transform here to avoid unneccesary work if the guard above fails
-        modelViewTransform.setAsSDLgpuMatrix()
+        // We only actually set the transform here to avoid unneccesary work if the guard above fails.
+        //
+        // Layers that draw a solid fill (background / border) snap their translation to whole device
+        // pixels so abutting fills meet with no sub-pixel gap (see `pixelSnappingTranslation`) — that
+        // closes fill-to-fill seams like the thin dark line above the progress bar on Android.
+        // Everything else (plain containers, image/content layers) keeps the exact transform, so
+        // blitted images stay smooth and we skip an extra matrix set + blit-buffer flush per layer.
+        let drawsFill = backgroundColor != nil || borderWidth > 0
+        if drawsFill {
+            renderer.pixelSnappingTranslation(of: modelViewTransform).setAsSDLgpuMatrix()
+        } else {
+            modelViewTransform.setAsSDLgpuMatrix()
+        }
 
 
         // MARK: Masking / clipping rect
@@ -101,6 +112,11 @@ extension CALayer {
                     cornerRadius: 2
                 )
             }
+        }
+
+        // Back to the exact (un-snapped) transform for content + sublayers (only fills were snapped).
+        if drawsFill {
+            modelViewTransform.setAsSDLgpuMatrix()
         }
 
         if needsDisplay() {

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -43,19 +43,8 @@ extension CALayer {
 
         self.hasBeenRenderedInThisPartOfOverallLayerHierarchy = true
 
-        // We only actually set the transform here to avoid unneccesary work if the guard above fails.
-        //
-        // Layers that draw a solid fill (background / border) snap their translation to whole device
-        // pixels so abutting fills meet with no sub-pixel gap (see `pixelSnappingTranslation`) — that
-        // closes fill-to-fill seams that would otherwise show the backdrop through as a thin line.
-        // Everything else (plain containers, image/content layers) keeps the exact transform, so
-        // blitted images stay smooth and we skip an extra matrix set + blit-buffer flush per layer.
-        let drawsFill = backgroundColor != nil || borderWidth > 0
-        if drawsFill {
-            renderer.pixelSnappingTranslation(of: modelViewTransform).setAsSDLgpuMatrix()
-        } else {
-            modelViewTransform.setAsSDLgpuMatrix()
-        }
+        // We only actually set the transform here to avoid unneccesary work if the guard above fails
+        modelViewTransform.setAsSDLgpuMatrix()
 
 
         // MARK: Masking / clipping rect
@@ -112,11 +101,6 @@ extension CALayer {
                     cornerRadius: 2
                 )
             }
-        }
-
-        // Back to the exact (un-snapped) transform for content + sublayers (only fills were snapped).
-        if drawsFill {
-            modelViewTransform.setAsSDLgpuMatrix()
         }
 
         if needsDisplay() {

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -47,7 +47,7 @@ extension CALayer {
         //
         // Layers that draw a solid fill (background / border) snap their translation to whole device
         // pixels so abutting fills meet with no sub-pixel gap (see `pixelSnappingTranslation`) — that
-        // closes fill-to-fill seams like the thin dark line above the progress bar on Android.
+        // closes fill-to-fill seams that would otherwise show the backdrop through as a thin line.
         // Everything else (plain containers, image/content layers) keeps the exact transform, so
         // blitted images stay smooth and we skip an extra matrix set + blit-buffer flush per layer.
         let drawsFill = backgroundColor != nil || borderWidth > 0

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -107,14 +107,13 @@ extension FragmentShader {
             float d = sdRoundedBox(absolutePixelPos - center, halfSize, r);
             float aa = max(fwidth(d), 1e-5) * 0.5;
 
-            // Antialias outward: the fill is fully opaque up to its boundary (d <= 0) and the fade
-            // sits just outside (d in [0, 2aa]). We can't blend at the boundary itself: these shapes
-            // may be composited straight over a dark backdrop, so a partially-covered edge pixel —
-            // whether transparent (inward AA) or 50% (centered AA) — reads as a thin dark ring around
-            // the shape. Opaque-to-edge avoids that; the outward fade needs room, so `fill`/`outline`
-            // enlarge the draw quad.
-            float outer = 1.0 - smoothstep(0.0, 2.0 * aa, d);
-            float inner = 1.0 - smoothstep(0.0, 2.0 * aa, d + borderWidth);
+            // Centred anti-aliasing: the fade straddles the true boundary (d in [-aa, aa]), so the
+            // 50%-coverage contour lands exactly on the geometric edge and the shape keeps its real
+            // size. The caller snaps this rect's edges to the pixel grid, so on straight runs no pixel
+            // centre falls in the fade band (crisp, seam-free edges); the corner arcs still cross pixel
+            // centres, so that's effectively the only place the fade is visible.
+            float outer = 1.0 - smoothstep(-aa, aa, d);
+            float inner = 1.0 - smoothstep(-aa, aa, d + borderWidth);
             float alpha = outer - inner;
 
             \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -109,10 +109,10 @@ extension FragmentShader {
 
             // Antialias outward: the fill is fully opaque up to its boundary (d <= 0) and the fade
             // sits just outside (d in [0, 2aa]). We can't blend at the boundary itself: these shapes
-            // are composited straight over the background-less (dark) PlayerView on Android, so a
-            // partially-covered edge pixel — whether transparent (inward AA) or 50% (centered AA) —
-            // reads as a thin dark ring around the shape. Opaque-to-edge avoids that; the outward
-            // fade needs room, so `fill`/`outline` enlarge the draw quad.
+            // may be composited straight over a dark backdrop, so a partially-covered edge pixel —
+            // whether transparent (inward AA) or 50% (centered AA) — reads as a thin dark ring around
+            // the shape. Opaque-to-edge avoids that; the outward fade needs room, so `fill`/`outline`
+            // enlarge the draw quad.
             float outer = 1.0 - smoothstep(0.0, 2.0 * aa, d);
             float inner = 1.0 - smoothstep(0.0, 2.0 * aa, d + borderWidth);
             float alpha = outer - inner;

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -107,10 +107,14 @@ extension FragmentShader {
             float d = sdRoundedBox(absolutePixelPos - center, halfSize, r);
             float aa = max(fwidth(d), 1e-5) * 0.5;
 
-            // Antialias inward (the fade sits at d in [-2aa, 0], entirely inside the shape) so the
-            // edge never bleeds past the shape boundary and gets clipped by the draw quad.
-            float outer = 1.0 - smoothstep(-2.0 * aa, 0.0, d);
-            float inner = 1.0 - smoothstep(-2.0 * aa, 0.0, d + borderWidth);
+            // Antialias outward: the fill is fully opaque up to its boundary (d <= 0) and the fade
+            // sits just outside (d in [0, 2aa]). We can't blend at the boundary itself: these shapes
+            // are composited straight over the background-less (dark) PlayerView on Android, so a
+            // partially-covered edge pixel — whether transparent (inward AA) or 50% (centered AA) —
+            // reads as a thin dark ring around the shape. Opaque-to-edge avoids that; the outward
+            // fade needs room, so `fill`/`outline` enlarge the draw quad.
+            float outer = 1.0 - smoothstep(0.0, 2.0 * aa, d);
+            float inner = 1.0 - smoothstep(0.0, 2.0 * aa, d + borderWidth);
             float alpha = outer - inner;
 
             \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -82,23 +82,13 @@ extension UIScreen {
         GPU_Clear(rawPointer)
     }
 
-    /// Snap only a transform's translation (m41/m42) to whole device pixels, leaving scale/rotation
-    /// untouched. Used for solid fills so abutting fills land on the same physical pixel (no seam);
-    /// animating/scrolling content keeps its exact sub-pixel transform so motion stays smooth.
-    func pixelSnappingTranslation(of transform: CATransform3D) -> CATransform3D {
-        let scale = deviceScale
-        var snapped = transform
-        snapped.m41 = Float(snapToPixel(CGFloat(transform.m41), scale: scale.x))
-        snapped.m42 = Float(snapToPixel(CGFloat(transform.m42), scale: scale.y))
-        return snapped
-    }
-
     func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
         if cornerRadius >= 1 {
+            let snappedRect = pixelSnapped(rect)
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
-            ShaderProgram.roundedRect.setFill(rect: rect, cornerRadius: cornerRadius)
-            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: rect), color: color.sdlColor)
+            ShaderProgram.roundedRect.setFill(rect: snappedRect, cornerRadius: cornerRadius)
+            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: snappedRect), color: color.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
@@ -124,10 +114,11 @@ extension UIScreen {
         if cornerRadius > 1 {
             // SDF ring: stroke is drawn from the rect boundary inward by `lineThickness`,
             // which matches CSS/iOS "border" semantics.
+            let snappedRect = pixelSnapped(rect)
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
-            ShaderProgram.roundedRect.setStroke(rect: rect, cornerRadius: cornerRadius, borderWidth: lineThickness)
-            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: rect), color: lineColor.sdlColor)
+            ShaderProgram.roundedRect.setStroke(rect: snappedRect, cornerRadius: cornerRadius, borderWidth: lineThickness)
+            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: snappedRect), color: lineColor.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             outline(rect, lineColor: lineColor, lineThickness: lineThickness)
@@ -170,32 +161,39 @@ private extension UIScreen {
         (value * scale).rounded() / scale
     }
 
-    // The rounded-rect shader anti-aliases just *outside* the shape, over a band up to ~2 device
-    // pixels wide at a corner (`fwidth`), so the quad we draw must extend past `rect` by that band
-    // or the fade gets clipped. Pad by 2 device pixels per side (converted to points via the scale);
-    // the SDF still uses the original `rect`, so these extra fragments simply shade to zero.
-    func roundedShaderQuad(for rect: CGRect) -> GPU_Rect {
+    // Snap a rounded-rect's *edges* to physical pixels (only the SDF path uses this). The edges are
+    // snapped in *screen* space — the shape's on-screen position is `rect` plus the current model-view
+    // translation, and the sub-pixel part usually lives in that translation, so we fold it in, snap,
+    // then subtract it back to return a local rect. With the shader's centred anti-aliasing, a straight
+    // edge landing on a physical pixel line keeps every pixel centre out of the fade band, so the edge
+    // stays crisp and two abutting fills land on the same line with no backdrop seam — and identically
+    // regardless of where the menu sits. The corner arcs still cross pixel centres and get the fade.
+    // Nothing else is snapped: plain fills, clip rects and content/animation keep their exact positions.
+    func pixelSnapped(_ rect: CGRect) -> CGRect {
+        let modelViewTransform = CATransform3D(unsafePointer: GPU_GetCurrentMatrix())
+        let translationX = CGFloat(modelViewTransform.m41)
+        let translationY = CGFloat(modelViewTransform.m42)
         let scale = deviceScale
-        let padX = 2 / scale.x
-        let padY = 2 / scale.y
-        return gpuRect(CGRect(
-            x: rect.minX - padX,
-            y: rect.minY - padY,
-            width: rect.width + 2 * padX,
-            height: rect.height + 2 * padY
-        ))
+
+        let left = snapToPixel(rect.minX + translationX, scale: scale.x) - translationX
+        let top = snapToPixel(rect.minY + translationY, scale: scale.y) - translationY
+        let right = snapToPixel(rect.maxX + translationX, scale: scale.x) - translationX
+        let bottom = snapToPixel(rect.maxY + translationY, scale: scale.y) - translationY
+        return CGRect(x: left, y: top, width: right - left, height: bottom - top)
     }
 
-    // Snap the *edges* to physical pixels rather than origin + size independently: rounding size on
-    // its own can render a view up to 1px shorter than its frame, opening a gap between abutting
-    // fills that shows the backdrop through as a thin line. Rounding edges instead lands a rect's
-    // far edge on the same physical pixel as an abutting rect's near edge.
-    func gpuRect(_ rect: CGRect) -> GPU_Rect {
+    // The rounded-rect shader's centred anti-aliasing straddles the boundary, so the fade extends ~half
+    // a device pixel *outside* `rect`. Grow the draw quad by one device pixel per side so that outer
+    // half of the fade has fragments to shade; the SDF still uses the original `rect`, so the extra
+    // fragments shade to zero and the shape isn't enlarged.
+    func roundedShaderQuad(for rect: CGRect) -> GPU_Rect {
         let scale = deviceScale
-        let left = snapToPixel(rect.minX, scale: scale.x)
-        let top = snapToPixel(rect.minY, scale: scale.y)
-        let right = snapToPixel(rect.maxX, scale: scale.x)
-        let bottom = snapToPixel(rect.maxY, scale: scale.y)
-        return GPU_Rect(x: Float(left), y: Float(top), w: Float(right - left), h: Float(bottom - top))
+        return gpuRect(rect.insetBy(dx: -1 / scale.x, dy: -1 / scale.y))
+    }
+
+    // Straight conversion into GPU (point) coordinates — no pixel snapping. Coordinates pass through
+    // exactly so abutting fills share the same edge and animating/scrolling content stays smooth.
+    func gpuRect(_ rect: CGRect) -> GPU_Rect {
+        GPU_Rect(x: Float(rect.minX), y: Float(rect.minY), w: Float(rect.width), h: Float(rect.height))
     }
 }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -187,10 +187,9 @@ private extension UIScreen {
     }
 
     // Snap the *edges* to physical pixels rather than origin + size independently: rounding size on
-    // its own can render a view up to 1px shorter than its frame, opening a gap that shows the dark
-    // area behind the background-less PlayerView on Android as a thin line (e.g. above the progress
-    // bar). Rounding edges instead lands a rect's far edge on the same physical pixel as an abutting
-    // rect's near edge.
+    // its own can render a view up to 1px shorter than its frame, opening a gap between abutting
+    // fills that shows the backdrop through as a thin line. Rounding edges instead lands a rect's
+    // far edge on the same physical pixel as an abutting rect's near edge.
     func gpuRect(_ rect: CGRect) -> GPU_Rect {
         let scale = deviceScale
         let left = snapToPixel(rect.minX, scale: scale.x)

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -82,12 +82,23 @@ extension UIScreen {
         GPU_Clear(rawPointer)
     }
 
+    /// Snap only a transform's translation (m41/m42) to whole device pixels, leaving scale/rotation
+    /// untouched. Used for solid fills so abutting fills land on the same physical pixel (no seam);
+    /// animating/scrolling content keeps its exact sub-pixel transform so motion stays smooth.
+    func pixelSnappingTranslation(of transform: CATransform3D) -> CATransform3D {
+        let scale = deviceScale
+        var snapped = transform
+        snapped.m41 = Float(snapToPixel(CGFloat(transform.m41), scale: scale.x))
+        snapped.m42 = Float(snapToPixel(CGFloat(transform.m42), scale: scale.y))
+        return snapped
+    }
+
     func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
         if cornerRadius >= 1 {
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
             ShaderProgram.roundedRect.setFill(rect: rect, cornerRadius: cornerRadius)
-            GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
+            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: rect), color: color.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             GPU_RectangleFilled(rawPointer, gpuRect(rect), color: color.sdlColor)
@@ -116,7 +127,7 @@ extension UIScreen {
             let previousProgram = ShaderProgram.currentlyActive
             ShaderProgram.roundedRect.activate()
             ShaderProgram.roundedRect.setStroke(rect: rect, cornerRadius: cornerRadius, borderWidth: lineThickness)
-            GPU_RectangleFilled(rawPointer, gpuRect(rect), color: lineColor.sdlColor)
+            GPU_RectangleFilled(rawPointer, roundedShaderQuad(for: rect), color: lineColor.sdlColor)
             restoreShaderProgram(previousProgram)
         } else {
             outline(rect, lineColor: lineColor, lineThickness: lineThickness)
@@ -148,17 +159,44 @@ extension UIScreen {
 }
 
 private extension UIScreen {
-    // Snap to physical pixel boundaries using the GPU target's per-axis ratios —
-    // a single `UIScreen.scale` is wrong when drawable_w/target_w ≠ drawable_h/target_h
-    // (any fractional density rounds the two axes by different amounts).
+    /// The GPU target's device-pixel ratio per axis (drawable / target). Per-axis because a single
+    /// `UIScreen.scale` is wrong when the two axes round differently at fractional densities.
+    var deviceScale: (x: CGFloat, y: CGFloat) {
+        (CGFloat(rawPointer.pointee.context.pointee.drawable_w) / CGFloat(rawPointer.pointee.w),
+         CGFloat(rawPointer.pointee.context.pointee.drawable_h) / CGFloat(rawPointer.pointee.h))
+    }
+
+    func snapToPixel(_ value: CGFloat, scale: CGFloat) -> CGFloat {
+        (value * scale).rounded() / scale
+    }
+
+    // The rounded-rect shader anti-aliases just *outside* the shape, over a band up to ~2 device
+    // pixels wide at a corner (`fwidth`), so the quad we draw must extend past `rect` by that band
+    // or the fade gets clipped. Pad by 2 device pixels per side (converted to points via the scale);
+    // the SDF still uses the original `rect`, so these extra fragments simply shade to zero.
+    func roundedShaderQuad(for rect: CGRect) -> GPU_Rect {
+        let scale = deviceScale
+        let padX = 2 / scale.x
+        let padY = 2 / scale.y
+        return gpuRect(CGRect(
+            x: rect.minX - padX,
+            y: rect.minY - padY,
+            width: rect.width + 2 * padX,
+            height: rect.height + 2 * padY
+        ))
+    }
+
+    // Snap the *edges* to physical pixels rather than origin + size independently: rounding size on
+    // its own can render a view up to 1px shorter than its frame, opening a gap that shows the dark
+    // area behind the background-less PlayerView on Android as a thin line (e.g. above the progress
+    // bar). Rounding edges instead lands a rect's far edge on the same physical pixel as an abutting
+    // rect's near edge.
     func gpuRect(_ rect: CGRect) -> GPU_Rect {
-        let scaleX = CGFloat(rawPointer.pointee.context.pointee.drawable_w) / CGFloat(rawPointer.pointee.w)
-        let scaleY = CGFloat(rawPointer.pointee.context.pointee.drawable_h) / CGFloat(rawPointer.pointee.h)
-        return GPU_Rect(
-            x: Float((rect.origin.x * scaleX).rounded() / scaleX),
-            y: Float((rect.origin.y * scaleY).rounded() / scaleY),
-            w: Float((rect.size.width * scaleX).rounded() / scaleX),
-            h: Float((rect.size.height * scaleY).rounded() / scaleY)
-        )
+        let scale = deviceScale
+        let left = snapToPixel(rect.minX, scale: scale.x)
+        let top = snapToPixel(rect.minY, scale: scale.y)
+        let right = snapToPixel(rect.maxX, scale: scale.x)
+        let bottom = snapToPixel(rect.maxY, scale: scale.y)
+        return GPU_Rect(x: Float(left), y: Float(top), w: Float(right - left), h: Float(bottom - top))
     }
 }


### PR DESCRIPTION
**Type of change:** bugfix

## Motivation (current vs expected behavior)

**Issue:** thin 1px dark lines appear along the edges of filled shapes when they're composited directly over a dark, background-less surface. Two independent causes, both pixel-snapping related:

- **Rounded fills/borders** (the SDF rounded-rect shader): the edge is anti-aliased with partial coverage right at the boundary, so over a dark backdrop those edge pixels read as a thin dark ring around the shape.
- **Plain rectangular fills**: two abutting fills can leave a 1px crack showing the backdrop, because `gpuRect` snapped each rect's `origin` and `size` to device pixels *independently* — so a rect's far edge could land on a different physical pixel than the near edge of the rect it abuts.

Expected: shapes render edge-to-edge with no dark seam, as they do when composited over an opaque backdrop.

## Fix

- **Rounded shapes** — anti-alias *outward*: the fill stays fully opaque up to its boundary and the AA fade sits just outside it (the draw quad is enlarged so that outer fade isn't clipped). A partially-covered boundary pixel — whether transparent or 50% — is what reads as a ring over a dark backdrop; opaque-to-edge avoids it while keeping the edges smooth.
- **Plain rects** — `gpuRect` now snaps the rect's *edges* (min/max) to whole device pixels and derives width/height from those, so an abutting rect's near edge resolves to the same physical pixel. Fill-drawing layers (background/border) additionally snap their *translation* to whole pixels (`pixelSnappingTranslation`); plain containers and image/content layers keep their exact transform, so blitted and scrolling content stays smooth.

<img width="2340" height="1080" alt="2026-07-08_20 40 25" src="https://github.com/user-attachments/assets/def6a509-d57d-4c16-9c4f-65d6152e0e64" />
 
<img width="2560" height="1600" alt="2026-07-08_17 03 35" src="https://github.com/user-attachments/assets/a2ce0b4d-2ea4-4762-912c-f283411049cd" />

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
