### PR TITLE
 Render CALayer drop shadows (+ UIBezierPath)

### DIFF
--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -73,6 +73,21 @@ extension CALayer {
             }
         }
 
+        // Core Animation draws a layer's shadow automatically on iOS; the SDL renderer doesn't, so we
+        // render a feathered fill *behind* the layer's own background, honouring shadowColor / Offset /
+        // Radius / Opacity and shadowPath. The shadow follows `shadowPath` if set (its own rect and
+        // corner radius, given in the layer's coordinate space), otherwise the layer's rounded bounds.
+        let shadowAlpha = shadowColor == nil ? 0 : shadowOpacity * opacity
+        if let shadowColor, shadowAlpha > 0.01 {
+            let shadowShape = shadowPath?.boundingBox.offsetBy(deltaFromAnchorPointToOrigin) ?? renderedBoundsRelativeToAnchorPoint
+            renderer.shadow(
+                shadowShape.offsetBy(CGPoint(x: shadowOffset.width, y: shadowOffset.height)),
+                color: shadowColor.withAlphaComponent(CGFloat(shadowAlpha)),
+                cornerRadius: shadowPath?.cornerRadius ?? cornerRadius,
+                blurRadius: shadowRadius
+            )
+        }
+
         if let backgroundColor = backgroundColor {
             let backgroundColorOpacity = opacity * backgroundColor.alphaValue.toNormalisedFloat()
             renderer.fill(
@@ -89,18 +104,6 @@ extension CALayer {
                 lineThickness: borderWidth,
                 cornerRadius: cornerRadius
             )
-        }
-
-        if let shadowPath = shadowPath, let shadowColor = shadowColor {
-            let absoluteShadowOpacity = shadowOpacity * opacity * 0.5 // for "shadow" effect ;)
-
-            if absoluteShadowOpacity > 0.01 {
-                renderer.fill(
-                    shadowPath.offsetBy(deltaFromAnchorPointToOrigin),
-                    with: shadowColor.withAlphaComponent(CGFloat(absoluteShadowOpacity)),
-                    cornerRadius: 2
-                )
-            }
         }
 
         if needsDisplay() {

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -166,7 +166,7 @@ open class CALayer {
     // TODO: Implement these!
     public var borderWidth: CGFloat = 0
     public var borderColor: CGColor = UIColor.black.cgColor
-    public var shadowPath: CGRect?
+    public var shadowPath: CGPath?
     public var shadowColor: CGColor?
     public var shadowOpacity: Float = 0
     public var shadowOffset: CGSize = .zero

--- a/Sources/CGPath.swift
+++ b/Sources/CGPath.swift
@@ -6,10 +6,22 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-public typealias CGPath = CGRect
+/// A minimal cross-platform stand-in for CoreGraphics' `CGPath`. The SDL renderer can only draw
+/// rounded rectangles, so a path is represented by its bounding rectangle plus a corner radius —
+/// enough for the rect / rounded-rect / oval shapes `UIBezierPath` produces (which is all the app
+/// relies on cross-platform, e.g. `CALayer.shadowPath`). Freeform paths (move/addLine/curves) are
+/// not modelled: there is no initializer for them, so misuse is a compile error, not a silent
+/// mis-render.
+public struct CGPath {
+    public let boundingBox: CGRect
+    public let cornerRadius: CGFloat
 
-extension CGPath {
+    init(boundingBox: CGRect, cornerRadius: CGFloat) {
+        self.boundingBox = boundingBox
+        self.cornerRadius = cornerRadius
+    }
+
     public init(rect: CGRect, transform: CGAffineTransform?) {
-        self = rect
+        self.init(boundingBox: rect, cornerRadius: 0)
     }
 }

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -53,9 +53,18 @@ extension FragmentShader {
         return shader
     }
 
+    private static var _roundedRectShadow: FragmentShader?
+    static var roundedRectShadow: FragmentShader {
+        if let existing = _roundedRectShadow { return existing }
+        let shader = try! FragmentShader(source: roundedRectShadowSource)
+        _roundedRectShadow = shader
+        return shader
+    }
+
     static func invalidateAll() {
         _maskColourWithImage = nil
         _roundedRect = nil
+        _roundedRectShadow = nil
     }
 
     private static let maskColourWithImageSource = """
@@ -115,6 +124,43 @@ extension FragmentShader {
             float outer = 1.0 - smoothstep(-aa, aa, d);
             float inner = 1.0 - smoothstep(-aa, aa, d + borderWidth);
             float alpha = outer - inner;
+
+            \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);
+        }
+        """
+
+    // SDF rounded-rect drop shadow: like the rounded-rect fill but with a soft, symmetric edge
+    // falloff (`blurRadius`) instead of a 1px AA — the SDL renderer has no automatic layer shadow,
+    // so this draws a blurred rounded rect to mimic Core Animation's `shadow*` (the caller passes
+    // the shape rect — the layer bounds or its shadowPath).
+    private static let roundedRectShadowSource = """
+        \(`in`) vec4 originalColour;
+        \(`in`) vec2 absolutePixelPos;
+
+        \(fragColorDefinition)
+
+        uniform vec4 rectFrame;
+        uniform float cornerRadius;
+        uniform float blurRadius;
+
+        float sdRoundedBox(vec2 p, vec2 b, float r) {
+            vec2 q = abs(p) - b + r;
+            return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r;
+        }
+
+        void main(void)
+        {
+            vec2 halfSize = vec2(rectFrame.w, rectFrame.z) * 0.5;
+            vec2 center = vec2(rectFrame.x, rectFrame.y) + halfSize;
+            float r = min(cornerRadius, min(halfSize.x, halfSize.y));
+
+            float d = sdRoundedBox(absolutePixelPos - center, halfSize, r);
+
+            // Soft, symmetric falloff centred on the shape edge (approximates a Gaussian):
+            // it reads as a blurred shadow rather than a hard offset band. The edge sits at
+            // 50% and fades to 0 by `blurRadius` outside / to 1 by `blurRadius` inside.
+            float blur = max(blurRadius, 1e-5);
+            float alpha = 1.0 - smoothstep(-blur, blur, d);
 
             \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);
         }

--- a/Sources/ShaderProgram+shadow.swift
+++ b/Sources/ShaderProgram+shadow.swift
@@ -1,0 +1,38 @@
+//
+//  ShaderProgram+shadow.swift
+//  UIKit
+//
+
+internal import SDL_gpu
+
+extension ShaderProgram {
+    private static var _shadow: ShadowShaderProgram?
+    static var shadow: ShadowShaderProgram {
+        if let existing = _shadow { return existing }
+        let program = try! ShadowShaderProgram()
+        _shadow = program
+        return program
+    }
+    static func invalidateShadow() { _shadow = nil }
+}
+
+class ShadowShaderProgram: ShaderProgram {
+    private var rectFrame: UniformVariable!
+    private var cornerRadius: UniformVariable!
+    private var blurRadius: UniformVariable!
+
+    fileprivate init() throws {
+        try super.init(vertexShader: .common, fragmentShader: .roundedRectShadow)
+        rectFrame = UniformVariable("rectFrame", in: programRef)
+        cornerRadius = UniformVariable("cornerRadius", in: programRef)
+        blurRadius = UniformVariable("blurRadius", in: programRef)
+    }
+
+    /// Set the rounded-rect shadow uniforms. (The caller — `UIScreen.shadow` — expands the draw
+    /// quad by `blur` so the feathered edge isn't clipped.)
+    func setShadow(rect: CGRect, cornerRadius radius: CGFloat, blurRadius blur: CGFloat) {
+        rectFrame.set(rect)
+        cornerRadius.set(Float(radius))
+        blurRadius.set(Float(blur))
+    }
+}

--- a/Sources/UIBezierPath.swift
+++ b/Sources/UIBezierPath.swift
@@ -1,0 +1,28 @@
+//
+//  UIBezierPath.swift
+//  UIKit
+//
+//  Copyright © flowkey. All rights reserved.
+//
+
+/// A minimal cross-platform `UIBezierPath` covering the shape constructors — the part the app uses
+/// cross-platform (e.g. building a `CALayer.shadowPath`). Freeform building (move/addLine/curves)
+/// and drawing (`stroke`/`fill`, which need a graphics context) are iOS-only and intentionally not
+/// provided here, so those uses stay behind `#if os(iOS)`.
+public class UIBezierPath {
+    public let cgPath: CGPath
+
+    public init(rect: CGRect) {
+        cgPath = CGPath(boundingBox: rect, cornerRadius: 0)
+    }
+
+    public init(roundedRect rect: CGRect, cornerRadius: CGFloat) {
+        cgPath = CGPath(boundingBox: rect, cornerRadius: cornerRadius)
+    }
+
+    public init(ovalIn rect: CGRect) {
+        // Our renderer draws rounded rectangles: a max corner radius is an exact circle for a
+        // square, and a stadium approximation for a non-square rect.
+        cgPath = CGPath(boundingBox: rect, cornerRadius: min(rect.width, rect.height) / 2)
+    }
+}

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -95,6 +95,17 @@ extension UIScreen {
         }
     }
 
+    /// Draw a feathered drop shadow: opaque inside `shapeRect`, fading to zero over `blurRadius`
+    /// pixels outside it (and up over the same distance inside). The draw quad is expanded by
+    /// `blurRadius` so the feathered edge isn't clipped.
+    func shadow(_ shapeRect: CGRect, color: UIColor, cornerRadius: CGFloat, blurRadius: CGFloat) {
+        let previousProgram = ShaderProgram.currentlyActive
+        ShaderProgram.shadow.activate()
+        ShaderProgram.shadow.setShadow(rect: shapeRect, cornerRadius: cornerRadius, blurRadius: blurRadius)
+        GPU_RectangleFilled(rawPointer, gpuRect(shapeRect.insetBy(dx: -blurRadius, dy: -blurRadius)), color: color.sdlColor)
+        restoreShaderProgram(previousProgram)
+    }
+
     func outline(_ rect: CGRect, lineColor: UIColor, lineThickness: CGFloat) {
         // we want to render the outline 'inside' the rect rather
         // than exceeding the bounds when lineThickness is bigger than 1

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -143,6 +143,7 @@ public final class UIScreen {
             FontRenderer.cleanupSession()
 
             ShaderProgram.invalidateRoundedRect()
+            ShaderProgram.invalidateShadow()
             ShaderProgram.invalidateMask()
             FragmentShader.invalidateAll()
             VertexShader.invalidateAll()

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		5CDB31B71F1CE8050081A605 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDB31B61F1CE8050081A605 /* Bundle.swift */; };
 		5CDC14CC1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDC14CB1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift */; };
 		FF0000010000000000000001 /* ShaderProgram+roundedRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */; };
+		FF0000010000000000000003 /* ShaderProgram+shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000004 /* ShaderProgram+shadow.swift */; };
+		FF0000010000000000000005 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000006 /* UIBezierPath.swift */; };
 		5CE5C56F1EDC39E100680154 /* UIPanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C56E1EDC39E100680154 /* UIPanGestureRecognizer.swift */; };
 		5CE5C5711EDC6AA100680154 /* UITapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C5701EDC6AA100680154 /* UITapGestureRecognizer.swift */; };
 		5CE5C5731EDD7C3400680154 /* UIWindow+TouchHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C5721EDD7C3400680154 /* UIWindow+TouchHandling.swift */; };
@@ -329,6 +331,8 @@
 		5CDB31B61F1CE8050081A605 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		5CDC14CB1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+mask.swift"; sourceTree = "<group>"; };
 		FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+roundedRect.swift"; sourceTree = "<group>"; };
+		FF0000010000000000000004 /* ShaderProgram+shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+shadow.swift"; sourceTree = "<group>"; };
+		FF0000010000000000000006 /* UIBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBezierPath.swift"; sourceTree = "<group>"; };
 		5CE5C56E1EDC39E100680154 /* UIPanGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIPanGestureRecognizer.swift; path = Sources/UIPanGestureRecognizer.swift; sourceTree = SOURCE_ROOT; };
 		5CE5C5701EDC6AA100680154 /* UITapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITapGestureRecognizer.swift; path = Sources/UITapGestureRecognizer.swift; sourceTree = SOURCE_ROOT; };
 		5CE5C5721EDD7C3400680154 /* UIWindow+TouchHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+TouchHandling.swift"; sourceTree = "<group>"; };
@@ -645,6 +649,8 @@
 				5C664CD71FA0E640008F41D6 /* ShaderProgram.swift */,
 				5CDC14CB1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift */,
 				FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */,
+				FF0000010000000000000004 /* ShaderProgram+shadow.swift */,
+				FF0000010000000000000006 /* UIBezierPath.swift */,
 			);
 			name = Shaders;
 			path = Sources;
@@ -949,6 +955,8 @@
 				5B71D7472292B68E008CEC66 /* UIAccessibilityIdentification.swift in Sources */,
 				5CDC14CC1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift in Sources */,
 				FF0000010000000000000001 /* ShaderProgram+roundedRect.swift in Sources */,
+				FF0000010000000000000003 /* ShaderProgram+shadow.swift in Sources */,
+				FF0000010000000000000005 /* UIBezierPath.swift in Sources */,
 				5BC6F7A81F4B1A3600F9C432 /* CABasicAnimation+updateProgress.swift in Sources */,
 				5BB2C09B2F1140870033F0AD /* CAGradientLayer.swift in Sources */,
 				83AB7B5C1F2B6A2000C7997D /* UIGestureRecognizerDelegate.swift in Sources */,


### PR DESCRIPTION
**Type of change:** feature

## Motivation (current vs expected behavior)

**Current:** the SDL renderer never shows a layer's shadow. It only drew one when `shadowPath` was set — and even then as a plain, unblurred fill with a hardcoded corner radius — and ignored `shadowColor` / `shadowOffset` / `shadowRadius` / `shadowOpacity`, which Core Animation uses to draw shadows automatically on iOS. `shadowPath` couldn't be set cross-platform anyway (`UIBezierPath` didn't exist; `CGPath` was just `typealias CGPath = CGRect`), so nothing rendered.

**Expected:** shadows render from the standard UIKit API and match iOS on both platforms.

## Fix

- A new SDF shadow shader draws a feathered fill behind the layer, honouring `shadowColor` / `shadowOffset` / `shadowRadius` / `shadowOpacity`, following `shadowPath` when set (otherwise the layer's rounded bounds) and clipped by `masksToBounds` — as on iOS. The blur is a smoothstep approximation of a Gaussian.
- `UIBezierPath` with the shape initializers (`rect` / `roundedRect` / `ovalIn`) plus a rounded-rect-capable `CGPath`, so `shadowPath` is `CGPath?` cross-platform. Freeform paths (move/addLine/curves) aren't modelled.

<img width="2560" height="1600" alt="2026-07-08_23 21 58" src="https://github.com/user-attachments/assets/a5387740-3538-4c1f-b45d-d181cee21333" />

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
