### PR TITLE
Add multitouch support

### DIFF
--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -21,7 +21,10 @@ extension UIApplication {
             #if os(Android)
             if let uievent = UIEvent.from(e) {
                 sendEvent(uievent)
-                break
+                // Drain the rest of the queue this frame too — otherwise a fast two-finger pinch produces
+                // events faster than one-per-frame and they back up, so the gesture keeps "playing" for
+                // seconds after the fingers lift.
+                continue
             }
             #endif
 
@@ -186,52 +189,49 @@ extension SDL_Event {
     }
 }
 
+// Touches (up to two fingers, for pinch) flow through the normal `UIWindow.sendEvent` → hit-test →
+// recognizer path, exactly like the first finger. All active fingers live in one shared `UIEvent`; each SDL
+// event marks which finger changed. No pinch-specific side channel — the pinch recognizer just reads
+// `event.allTouches` like it would on iOS.
 extension UIEvent {
     @MainActor
     static func from(_ event: SDL_Event) -> UIEvent? {
         switch SDL_EventType(event.type) {
         case SDL_FINGERDOWN:
-            // XXX: minimal implementation for single touch
-            guard UIEvent.activeEvents.isEmpty else {
-                return nil
-            }
-
-            let newTouch = UITouch(
-                touchId: 0,
-                at: CGPoint(
-                    x: CGFloat(event.tfinger.x),
-                    y: CGFloat(event.tfinger.y)
-                ),
+            let touch = UITouch(
+                touchId: Int(event.tfinger.fingerId),
+                at: CGPoint.from(event.tfinger),
                 timestamp: event.timestampInSeconds
             )
-
-            return UIEvent(touch: newTouch)
+            if let activeEvent = UIEvent.activeEvents.first {
+                activeEvent.allTouches?.insert(touch)
+                activeEvent.changedTouch = touch
+                return activeEvent
+            }
+            return UIEvent(touch: touch)
 
         case SDL_FINGERMOTION:
-            if
-                let firstExistingEvent = UIEvent.activeEvents.first,
-                let matchingTouch = firstExistingEvent.allTouches?.first(where: { $0.touchId == event.tfinger.fingerId })
-            {
+            guard
+                let activeEvent = UIEvent.activeEvents.first,
+                let touch = activeEvent.allTouches?.first(where: { $0.touchId == Int(event.tfinger.fingerId) })
+            else { return nil }
 
-                matchingTouch.timestamp = event.timestampInSeconds
-                matchingTouch.phase = .moved
-                matchingTouch.updateAbsoluteLocation(.from(event.tfinger))
-                return firstExistingEvent
-            } else {
-                return nil
-            }
+            touch.updateAbsoluteLocation(.from(event.tfinger))
+            touch.timestamp = event.timestampInSeconds
+            touch.phase = .moved
+            activeEvent.changedTouch = touch
+            return activeEvent
 
         case SDL_FINGERUP:
-            if
-                let firstExistingEvent = UIEvent.activeEvents.first,
-                let matchingTouch = firstExistingEvent.allTouches?.first(where: { $0.touchId == event.tfinger.fingerId })
-            {
-                matchingTouch.timestamp = event.timestampInSeconds
-                matchingTouch.phase = .ended
-                return firstExistingEvent
-            } else {
-                return nil
-            }
+            guard
+                let activeEvent = UIEvent.activeEvents.first,
+                let touch = activeEvent.allTouches?.first(where: { $0.touchId == Int(event.tfinger.fingerId) })
+            else { return nil }
+
+            touch.timestamp = event.timestampInSeconds
+            touch.phase = .ended
+            activeEvent.changedTouch = touch
+            return activeEvent
 
         default:
             return nil

--- a/Sources/UIApplication+handleSDLEvents.swift
+++ b/Sources/UIApplication+handleSDLEvents.swift
@@ -189,10 +189,6 @@ extension SDL_Event {
     }
 }
 
-// Touches (up to two fingers, for pinch) flow through the normal `UIWindow.sendEvent` → hit-test →
-// recognizer path, exactly like the first finger. All active fingers live in one shared `UIEvent`; each SDL
-// event marks which finger changed. No pinch-specific side channel — the pinch recognizer just reads
-// `event.allTouches` like it would on iOS.
 extension UIEvent {
     @MainActor
     static func from(_ event: SDL_Event) -> UIEvent? {

--- a/Sources/UIEvent.swift
+++ b/Sources/UIEvent.swift
@@ -3,12 +3,19 @@ public class UIEvent {
     internal static var activeEvents = Set<UIEvent>()
 
     public var allTouches: Set<UITouch>?
+
+    /// The touch this delivery is about (the one that just began/moved/ended). `allTouches` still holds every
+    /// finger currently down, so a multi-touch recognizer like pinch reads that; single-touch recognizers act
+    /// on `changedTouch`.
+    internal weak var changedTouch: UITouch?
+
     public let timestamp = Timer().startTimeInMilliseconds
 
     public init() {}
 
     internal init(touch: UITouch) {
         allTouches = Set<UITouch>([touch])
+        changedTouch = touch
     }
 }
 

--- a/Sources/UIGestureRecognizer.swift
+++ b/Sources/UIGestureRecognizer.swift
@@ -80,16 +80,19 @@ extension UIGestureRecognizer {
             self.state != .cancelled && self.state != .failed
         else { return }
 
-        let otherRecognizersThatHaveBeganToRecogize = touch.gestureRecognizers.filter {
-            $0 != self && $0.state == .began
+        let otherActiveRecognizers = touch.gestureRecognizers.filter {
+            $0 != self && ($0.state == .began || $0.state == .changed)
         }
 
-        otherRecognizersThatHaveBeganToRecogize.forEach {
-            if $0.delegate?.gestureRecognizer($0, shouldRecognizeSimultaneouslyWith: self) == true {
-                return
-            }
+        otherActiveRecognizers.forEach { other in
+            // iOS lets two recognizers run together when *either* delegate opts in.
+            let recognizeSimultaneously =
+                other.delegate?.gestureRecognizer(other, shouldRecognizeSimultaneouslyWith: self) == true ||
+                self.delegate?.gestureRecognizer(self, shouldRecognizeSimultaneouslyWith: other) == true
 
-            $0.touchesCancelled([touch], with: UIEvent())
+            if recognizeSimultaneously { return }
+
+            other.touchesCancelled([touch], with: UIEvent())
         }
     }
 }

--- a/Sources/UIPanGestureRecognizer.swift
+++ b/Sources/UIPanGestureRecognizer.swift
@@ -57,7 +57,8 @@ open class UIPanGestureRecognizer: UIGestureRecognizer {
 
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
-        guard let trackedTouch = touches.first else { return }
+        // A pan follows a single finger; ignore additional fingers (e.g. the second finger of a pinch).
+        guard trackedTouch == nil, let trackedTouch = touches.first else { return }
         self.trackedTouch = trackedTouch
         initialTouchPoint = trackedTouch.location(in: nil)
         touchesMovedTimestamp = trackedTouch.timestamp
@@ -68,11 +69,10 @@ open class UIPanGestureRecognizer: UIGestureRecognizer {
         super.touchesMoved(touches, with: event)
         guard
             let trackedTouch = trackedTouch,
-            touches.first == trackedTouch,
+            touches.contains(trackedTouch),
             let initialTouchPoint = initialTouchPoint
         else {
-            state = .failed
-            return
+            return // not our finger moving (e.g. the pinch's second finger); leave our state untouched
         }
 
         let location = trackedTouch.location(in: nil)

--- a/Sources/UIPinchGestureRecognizer.swift
+++ b/Sources/UIPinchGestureRecognizer.swift
@@ -7,5 +7,51 @@
 //
 
 public class UIPinchGestureRecognizer: UIGestureRecognizer {
+    /// Incremental scale factor since the last `.changed` callback (iOS resets it in its action handler).
     public var scale: CGFloat = 1
+
+    private var previousDistance: CGFloat?
+
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesBegan(touches, with: event)
+        // A pinch needs two fingers; begins only once the second one lands.
+        guard let distance = Self.distance(between: event.allTouches) else { return }
+        // Track the finger that carries the recognizer hierarchy so simultaneous-recognition coordination
+        // can find the other recognizers (e.g. the scroll pan) on it.
+        trackedTouch = event.allTouches?.first(where: { !$0.gestureRecognizers.isEmpty }) ?? touches.first
+        previousDistance = distance
+        scale = 1
+        state = .began
+        // Recognizing runs the same simultaneous-recognition/cancellation coordination the other recognizers
+        // use, so the scroll view's pan is handled via its delegate (GestureOverlay) rather than by hand.
+        cancelOtherGestureRecognizersThatShouldNotRecognizeSimultaneously()
+    }
+
+    open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesMoved(touches, with: event)
+        guard
+            let previousDistance, previousDistance > 0,
+            let distance = Self.distance(between: event.allTouches), distance > 0
+        else { return }
+        scale = distance / previousDistance
+        self.previousDistance = distance
+        state = .changed
+        onAction?()
+    }
+
+    open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+        super.touchesEnded(touches, with: event)
+        guard previousDistance != nil else { return } // wasn't pinching
+        previousDistance = nil
+        scale = 1
+        trackedTouch = nil
+        state = .ended
+    }
+
+    private static func distance(between touches: Set<UITouch>?) -> CGFloat? {
+        guard let locations = touches?.map({ $0.location(in: nil) }), locations.count >= 2 else { return nil }
+        let dx = locations[0].x - locations[1].x
+        let dy = locations[0].y - locations[1].y
+        return (dx * dx + dy * dy).squareRoot()
+    }
 }

--- a/Sources/UIPinchGestureRecognizer.swift
+++ b/Sources/UIPinchGestureRecognizer.swift
@@ -7,23 +7,19 @@
 //
 
 public class UIPinchGestureRecognizer: UIGestureRecognizer {
-    /// Incremental scale factor since the last `.changed` callback (iOS resets it in its action handler).
+    /// Incremental scale since the last `.changed`, matching iOS (which resets it in the action handler).
     public var scale: CGFloat = 1
 
     private var previousDistance: CGFloat?
 
     open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
         super.touchesBegan(touches, with: event)
-        // A pinch needs two fingers; begins only once the second one lands.
         guard let distance = Self.distance(between: event.allTouches) else { return }
-        // Track the finger that carries the recognizer hierarchy so simultaneous-recognition coordination
-        // can find the other recognizers (e.g. the scroll pan) on it.
+        // Track a finger that owns a recognizer hierarchy, so cancellation can reach the pan to cancel it.
         trackedTouch = event.allTouches?.first(where: { !$0.gestureRecognizers.isEmpty }) ?? touches.first
         previousDistance = distance
         scale = 1
         state = .began
-        // Recognizing runs the same simultaneous-recognition/cancellation coordination the other recognizers
-        // use, so the scroll view's pan is handled via its delegate (GestureOverlay) rather than by hand.
         cancelOtherGestureRecognizersThatShouldNotRecognizeSimultaneously()
     }
 

--- a/Sources/UIView.swift
+++ b/Sources/UIView.swift
@@ -253,14 +253,39 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
             return convertToSuperview(point)
         }
 
-        // Slow path:
-        let selfAbsoluteOrigin = self.absoluteOrigin()
-        let otherAbsoluteOrigin = otherView.absoluteOrigin()
+        // General path: lift `point` up to the root (window) coordinate space applying every ancestor's
+        // transform, then push it back down into `otherView` undoing every ancestor's transform. Undoing the
+        // whole chain (not just one level) is what makes points convert correctly through a scaled ancestor,
+        // e.g. the zoomed sheet container.
+        let pointInRoot = pointInRootCoordinates(point)
+        return otherView.rootCoordinatesToLocal(pointInRoot)
+    }
 
-        let originDifference = (otherAbsoluteOrigin - selfAbsoluteOrigin)
+    /// Lifts a point from `self`'s coordinate space up into the root ancestor's (window) coordinate space.
+    private func pointInRootCoordinates(_ point: CGPoint) -> CGPoint {
+        var result = point
+        var view = self
+        while let superview = view.superview {
+            result = view.convertToSuperview(result)
+            view = superview
+        }
+        return result
+    }
 
-        // TODO: This is a hack. We don't properly incorporate all transforms up the tree.
-        return (point - originDifference).applying(otherView.superview?.transform.inverted() ?? .identity)
+    /// Pushes a point from the root ancestor's (window) coordinate space down into `self`'s coordinate space.
+    private func rootCoordinatesToLocal(_ point: CGPoint) -> CGPoint {
+        var chainToRoot: [UIView] = []
+        var view: UIView? = self
+        while let current = view {
+            chainToRoot.append(current)
+            view = current.superview
+        }
+        // chainToRoot is [self, parent, …, root]; descend root → self, one level per step.
+        var result = point
+        for index in stride(from: chainToRoot.count - 1, to: 0, by: -1) {
+            result = chainToRoot[index].convertToSubview(result, subview: chainToRoot[index - 1])
+        }
+        return result
     }
 
     private func convertToSuperview(_ point: CGPoint) -> CGPoint {
@@ -276,24 +301,6 @@ open class UIView: UIResponder, CALayerDelegate, UIAccessibilityIdentification {
         }
 
         return (point - subview.frame.origin).applying(invertedSubviewTransform) + subview.bounds.origin
-    }
-
-    /// Returns `self.frame.origin` in `window.bounds` coordinates
-    internal func absoluteOrigin() -> CGPoint {
-        var result: CGPoint = .zero
-        var view = self
-        while let superview = view.superview {
-            let translatedFrameOrigin = view.convert(.zero, to: superview)
-
-            // This is the important step:
-            // We start deep in the hierarchy and at every level multiply the total result by the parent transform
-            // Without this, we would be ignoring the fact that a transform in (e.g.) the UIWindow affects ALL
-            // its subviews and their subviews, rather than just one level at a time.
-            result = (result + translatedFrameOrigin).applying(superview.transform)
-            view = superview
-        }
-
-        return result
     }
 
     public func convert(_ point: CGPoint, from view: UIView?) -> CGPoint {

--- a/Sources/UIWindow.swift
+++ b/Sources/UIWindow.swift
@@ -33,10 +33,13 @@ public class UIWindow: UIView {
 
     public func sendEvent(_ event: UIEvent) {
         guard
-            let allTouches = event.allTouches,
-            let currentTouch = allTouches.first,
+            let currentTouch = event.changedTouch ?? event.allTouches?.first,
             let hitView = currentTouch.view ?? hitTest(currentTouch.location(in: nil), with: nil)
         else { return }
+
+        // Deliver only the touch that changed for this event; `event.allTouches` still exposes every finger
+        // down for multi-touch recognizers. For a single finger this is identical to before.
+        let phaseTouches: Set<UITouch> = [currentTouch]
 
         switch currentTouch.phase {
         case .began:
@@ -44,16 +47,16 @@ public class UIWindow: UIView {
             currentTouch.view = hitView
             currentTouch.gestureRecognizers = hitView.getRecognizerHierachy()
 
-            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesBegan(allTouches, with: event) }
+            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesBegan(phaseTouches, with: event) }
 
             if !currentTouch.hasBeenCancelledByAGestureRecognizer {
-                hitView.touchesBegan(allTouches, with: event)
+                hitView.touchesBegan(phaseTouches, with: event)
             }
 
         case .moved:
-            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesMoved(allTouches, with: event) }
+            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesMoved(phaseTouches, with: event) }
             if !currentTouch.hasBeenCancelledByAGestureRecognizer {
-                hitView.touchesMoved(allTouches, with: event)
+                hitView.touchesMoved(phaseTouches, with: event)
             }
 
         case .ended:
@@ -61,13 +64,16 @@ public class UIWindow: UIView {
             // otherwise `hasBeenCancelledByAGestureRecognizer` will be false because the state was reset already
             let hasBeenCancelledByAGestureRecognizer = currentTouch.hasBeenCancelledByAGestureRecognizer
 
-            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesEnded(allTouches, with: event) }
+            currentTouch.runTouchActionOnRecognizerHierachy { $0.touchesEnded(phaseTouches, with: event) }
 
             if !hasBeenCancelledByAGestureRecognizer {
-                hitView.touchesEnded(allTouches, with: event)
+                hitView.touchesEnded(phaseTouches, with: event)
             }
 
-            UIEvent.activeEvents.remove(event)
+            event.allTouches?.remove(currentTouch)
+            if event.allTouches?.isEmpty ?? true {
+                UIEvent.activeEvents.remove(event)
+            }
         }
     }
 }

--- a/UIKitTests/Gestures/TouchHandlingTests.swift
+++ b/UIKitTests/Gestures/TouchHandlingTests.swift
@@ -18,6 +18,7 @@ class TouchHandlingTests: XCTestCase {
     private var subsubview = UIView()
 
     override func setUp() {
+        UIEvent.activeEvents.removeAll() // isolate from touches a prior test may not have ended
         event = UIEvent()
         window = UIWindow(frame: CGRect(origin: .zero, size: CGSize(width: 1000, height: 1000)))
 
@@ -92,6 +93,38 @@ class TouchHandlingTests: XCTestCase {
         XCTAssertTrue(anotherRecognizer.onActionWasCalled)
     }
 
+    func testSecondFingerJoinsTheSameEvent() {
+        touchDown(id: 0, CGPoint(x: 100, y: 100))
+        touchDown(id: 1, CGPoint(x: 200, y: 100))
+
+        XCTAssertEqual(UIEvent.activeEvents.count, 1)
+        XCTAssertEqual(UIEvent.activeEvents.first?.allTouches?.count, 2)
+    }
+
+    func testPinchBeginsOnSecondFingerAndReportsScale() {
+        let pinch = UIPinchGestureRecognizer()
+        view.addGestureRecognizer(pinch)
+
+        touchDown(id: 0, CGPoint(x: 100, y: 100))
+        touchDown(id: 1, CGPoint(x: 200, y: 100)) // fingers 100pt apart
+        XCTAssertEqual(pinch.state, .began)
+
+        touchMove(id: 1, CGPoint(x: 300, y: 100)) // now 200pt apart, so scale doubles
+        XCTAssertEqual(pinch.state, .changed)
+        XCTAssertEqual(pinch.scale, 2, accuracy: 0.0001)
+    }
+
+    func testSingleFingerDoesNotBeginPinch() {
+        let pinch = UIPinchGestureRecognizer()
+        view.addGestureRecognizer(pinch)
+
+        touchDown(id: 0, CGPoint(x: 100, y: 100))
+        touchMove(id: 0, CGPoint(x: 150, y: 100))
+
+        XCTAssertEqual(pinch.state, .possible)
+        XCTAssertEqual(pinch.scale, 1)
+    }
+
 }
 
 private extension TouchHandlingTests {
@@ -149,5 +182,29 @@ private extension TouchHandlingTests {
             touch.phase = .ended
             window.sendEvent(event)
         }
+    }
+
+    // Multi-finger variants: an extra finger joins the existing active event, matching the real SDL path.
+    func touchDown(id: Int, _ point: CGPoint) {
+        let touch = UITouch(touchId: id, at: point, timestamp: 0)
+        touch.window = window
+        if let event = UIEvent.activeEvents.first {
+            event.allTouches?.insert(touch)
+            event.changedTouch = touch
+            window.sendEvent(event)
+        } else {
+            window.sendEvent(UIEvent(touch: touch))
+        }
+    }
+
+    func touchMove(id: Int, _ point: CGPoint) {
+        guard
+            let event = UIEvent.activeEvents.first,
+            let touch = event.allTouches?.first(where: { $0.touchId == id })
+        else { return }
+        touch.updateAbsoluteLocation(point)
+        touch.phase = .moved
+        event.changedTouch = touch
+        window.sendEvent(event)
     }
 }

--- a/UIKitTests/UIView/UIViewTests+convert.swift
+++ b/UIKitTests/UIView/UIViewTests+convert.swift
@@ -290,24 +290,20 @@ class UIViewPointConversionTests: XCTestCase {
             return CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
         }
     }
-
-    extension UIView {
-        // XXX: we shouldn't actually need this function. It should be the same as running
-        // `convert(self.bounds.origin, to: rootView)` or `to: touch.window)` etc.
-
-        /// Returns `self.frame.origin` in `window.bounds` coordinates
-        internal func absoluteOrigin() -> CGPoint {
-            let rootView = self.getRootView()
-            return convert(.zero, to: rootView)
-        }
-
-        func getRootView() -> UIView? {
-            var currentView: UIView = self
-            while let superview = currentView.superview {
-                currentView = superview
-            }
-
-            return currentView
-        }
-    }
 #endif
+
+// Test-only helper: the view's origin in its root's coordinates. It's just `convert(.zero, to: rootView)`,
+// so the tests using it also exercise `convert(_:to:)`.
+extension UIView {
+    func absoluteOrigin() -> CGPoint {
+        convert(.zero, to: getRootView())
+    }
+
+    func getRootView() -> UIView {
+        var currentView: UIView = self
+        while let superview = currentView.superview {
+            currentView = superview
+        }
+        return currentView
+    }
+}

--- a/UIKitTests/UIView/UIViewTests+convert.swift
+++ b/UIKitTests/UIView/UIViewTests+convert.swift
@@ -278,6 +278,25 @@ class UIViewPointConversionTests: XCTestCase {
         let convertedPoint = subview3.convert(CGPoint(x: 20, y: 10), to: window)
         XCTAssertEqual(convertedPoint, CGPoint(x: 116, y: 106))
     }
+
+    func testConvertIntoViewUnderAScaledAncestor() {
+        let root = UIView(frame: CGRect(x: 0, y: 0, width: 400, height: 400))
+
+        let scaledContainer = UIView()
+        scaledContainer.transform = CGAffineTransform(scaleX: 2, y: 2)
+        scaledContainer.frame = CGRect(x: 0, y: 0, width: 200, height: 200)
+        root.addSubview(scaledContainer)
+
+        let middle = UIView(frame: CGRect(x: 10, y: 10, width: 80, height: 80))
+        scaledContainer.addSubview(middle)
+
+        let inner = UIView(frame: CGRect(x: 5, y: 5, width: 20, height: 20))
+        middle.addSubview(inner)
+
+        // The scale sits on inner's grandparent, so converting into inner has to undo the whole ancestor
+        // chain's transforms, not just the direct parent's — the off-by-zoom-factor bug this rewrite fixed.
+        XCTAssertEqual(root.convert(CGPoint(x: 100, y: 100), to: inner), CGPoint(x: 35, y: 35))
+    }
 }
 
 #if os(iOS)


### PR DESCRIPTION
Adds two-finger touch handling to the SDL UIKit polyfill so views can pinch-to-zoom on Android/Mac:

- Build one shared multi-finger `UIEvent` from SDL finger events and deliver it through `sendEvent` (each event marks which finger changed).
- Add a real `UIPinchGestureRecognizer` driven by `event.allTouches`, a pan recognizer that locks to a single finger, and simultaneous pan+pinch coordination.

Also fixes `UIView.convert(_:to:)` to apply the **full** ancestor transform chain (lift to root, then descend to the target) instead of a single level, so points convert correctly through a scaled ancestor (e.g. a zoomed view) — replacing the old one-level hack.