### PR TITLE
Gradient layer gpu and mask support

### DIFF
--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -68,19 +68,31 @@ open class CAGradientLayer: CALayer {
 
         guard let target = GPU_GetTarget(image.rawPointer) else { return }
 
-        // Disable the target's camera (inverted on image targets) so a plain ortho + identity maps our
-        // rect 1:1 onto the texture; otherwise the shader's camera × projection × modelview draws off-target.
+        // This runs mid-parent-render-pass, so save every piece of shared GL state we touch and restore it
+        // via `defer` — that way any early return added below can't leak state into the outer pass.
         let savedClippingRect = UIScreen.main?.clippingRect
         UIScreen.main?.clippingRect = nil
         GPU_FlushBlitBuffer()
-
-        GPU_EnableCamera(target, false)
-        GPU_MatrixMode(GPU_PROJECTION); GPU_PushMatrix(); GPU_LoadIdentity()
-        GPU_Ortho(0, Float(pixelWidth), Float(pixelHeight), 0, -1, 1)
-        GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix(); GPU_LoadIdentity()
-
-        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
+        GPU_MatrixMode(GPU_PROJECTION); GPU_PushMatrix()
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix()
         GPU_SetShapeBlending(false)
+        defer {
+            ShaderProgram.deactivateAll()
+            GPU_FlushBlitBuffer()
+            GPU_MatrixMode(GPU_MODELVIEW); GPU_PopMatrix()
+            GPU_MatrixMode(GPU_PROJECTION); GPU_PopMatrix()
+            GPU_MatrixMode(GPU_MODELVIEW) // leave mode as the outer render pass expects it
+            GPU_SetShapeBlending(true)
+            UIScreen.main?.clippingRect = savedClippingRect
+        }
+
+        // Disable the target's camera (inverted on image targets) so a plain ortho + identity maps our
+        // rect 1:1 onto the texture; otherwise the shader's camera × projection × modelview draws off-target.
+        GPU_EnableCamera(target, false)
+        GPU_MatrixMode(GPU_PROJECTION); GPU_LoadIdentity()
+        GPU_Ortho(0, Float(pixelWidth), Float(pixelHeight), 0, -1, 1)
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_LoadIdentity()
+        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
         GPU_Clear(target)
 
         ShaderProgram.gradient.activate()
@@ -94,15 +106,6 @@ open class CAGradientLayer: CALayer {
                 : colors.indices.map { Float($0) / Float(max(colors.count - 1, 1)) }
         )
         GPU_RectangleFilled(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)), color: UIColor.white.sdlColor)
-
-        ShaderProgram.deactivateAll()
-        GPU_FlushBlitBuffer()
-
-        GPU_MatrixMode(GPU_MODELVIEW); GPU_PopMatrix()
-        GPU_MatrixMode(GPU_PROJECTION); GPU_PopMatrix()
-        GPU_MatrixMode(GPU_MODELVIEW)
-        GPU_SetShapeBlending(true)
-        UIScreen.main?.clippingRect = savedClippingRect
 
         contents = image
     }

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -1,3 +1,4 @@
+internal import SDL
 private import SDL_gpu
 
 open class CAGradientLayer: CALayer {
@@ -29,25 +30,91 @@ open class CAGradientLayer: CALayer {
         didSet { setNeedsDisplay() }
     }
 
-    /// Draw the gradient straight to the screen with the gradient shader — GPU-rasterised, with no
-    /// intermediate texture (the same mechanism `fill`/`shadow`/`roundedRect` use). Called by the render
-    /// walk (`CALayer+SDL`); `rect` is this layer's anchor-relative render rect.
+    // Rasterise the gradient once into `contents` on the GPU (render-to-texture), then the render walk
+    // blits that cached texture each frame like any image — recomputing only when the gradient changes
+    // (`setNeedsDisplay`). See the note in `display()` about disabling the render target's camera.
     @_optimize(speed)
-    func drawGradient(into renderer: UIScreen, rect: CGRect) {
-        guard !colors.isEmpty else { return }
+    override open func display() {
+        super.display()
 
-        // Implicit, evenly-spaced stop locations when none (or too few) are provided — matches CAGradientLayer.
-        let stops = locations.count >= colors.count
-            ? locations
-            : colors.indices.map { Float($0) / Float(max(colors.count - 1, 1)) }
+        if bounds.width.isZero || bounds.height.isZero { return }
 
-        renderer.gradientFill(
-            rect,
+        // Fill in implicit stop locations and collapse the degenerate cases.
+        if locations.count < colors.count {
+            if colors.count == 1 {
+                backgroundColor = colors[0]
+                colors = []
+                locations = []
+            } else {
+                locations = colors.indices.map { Float($0) / Float(colors.count - 1) }
+            }
+        }
+
+        if colors.isEmpty {
+            contents = nil
+            return
+        }
+
+        // Render-to-texture needs a live renderer/context. `display()` only runs inside the render walk
+        // (where the context is current), but guard so a stray call can't crash.
+        guard UIScreen.main != nil else { return }
+
+        let pixelWidth = Int(bounds.width * contentsScale)
+        let pixelHeight = Int(bounds.height * contentsScale)
+        guard pixelWidth > 0, pixelHeight > 0 else { return }
+
+        // Reuse the existing texture when it's already the right size, otherwise allocate one.
+        let image: CGImage
+        if let existing = contents, existing.width == pixelWidth, existing.height == pixelHeight {
+            image = existing
+        } else {
+            guard let newImage = CGImage(width: pixelWidth, height: pixelHeight) else { return }
+            image = newImage
+        }
+
+        guard let target = GPU_GetTarget(image.rawPointer) else { return }
+
+        // `display()` runs mid-render-walk, where a clip rect (screen-space GL scissor) may be active and
+        // the model-view holds the layer's on-screen transform — both would wrongly affect our offscreen
+        // draw. Disable them, and crucially disable the target's CAMERA: the shader's transform is
+        // camera × projection × modelview, and image targets default to `use_camera = true` (inverted),
+        // which otherwise pushes our rect off the target. With the camera off + a plain ortho + identity
+        // model-view, the rect (0,0,w,h) maps 1:1 onto the whole texture.
+        let savedClippingRect = UIScreen.main?.clippingRect
+        UIScreen.main?.clippingRect = nil
+        GPU_FlushBlitBuffer()
+
+        GPU_EnableCamera(target, false)
+        GPU_MatrixMode(GPU_PROJECTION); GPU_PushMatrix(); GPU_LoadIdentity()
+        GPU_Ortho(0, Float(pixelWidth), Float(pixelHeight), 0, -1, 1)
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix(); GPU_LoadIdentity()
+
+        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
+        GPU_SetShapeBlending(false) // write the gradient's own straight alpha, don't blend into the cleared texture
+        GPU_Clear(target)
+
+        ShaderProgram.gradient.activate()
+        ShaderProgram.gradient.set(
+            rect: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight),
             startPoint: startPoint,
             endPoint: endPoint,
             colors: _colors,
-            locations: stops
+            locations: locations.count >= colors.count
+                ? locations
+                : colors.indices.map { Float($0) / Float(max(colors.count - 1, 1)) }
         )
+        GPU_RectangleFilled(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)), color: UIColor.white.sdlColor)
+
+        ShaderProgram.deactivateAll()
+        GPU_FlushBlitBuffer()
+
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_PopMatrix()
+        GPU_MatrixMode(GPU_PROJECTION); GPU_PopMatrix()
+        GPU_MatrixMode(GPU_MODELVIEW)
+        GPU_SetShapeBlending(true)
+        UIScreen.main?.clippingRect = savedClippingRect
+
+        contents = image
     }
 }
 

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -30,16 +30,13 @@ open class CAGradientLayer: CALayer {
         didSet { setNeedsDisplay() }
     }
 
-    // Rasterise the gradient once into `contents` on the GPU (render-to-texture), then the render walk
-    // blits that cached texture each frame like any image — recomputing only when the gradient changes
-    // (`setNeedsDisplay`). See the note in `display()` about disabling the render target's camera.
+    // Rasterises the gradient into `contents` on the GPU, cached until the gradient changes.
     @_optimize(speed)
     override open func display() {
         super.display()
 
         if bounds.width.isZero || bounds.height.isZero { return }
 
-        // Fill in implicit stop locations and collapse the degenerate cases.
         if locations.count < colors.count {
             if colors.count == 1 {
                 backgroundColor = colors[0]
@@ -55,15 +52,12 @@ open class CAGradientLayer: CALayer {
             return
         }
 
-        // Render-to-texture needs a live renderer/context. `display()` only runs inside the render walk
-        // (where the context is current), but guard so a stray call can't crash.
         guard UIScreen.main != nil else { return }
 
         let pixelWidth = Int(bounds.width * contentsScale)
         let pixelHeight = Int(bounds.height * contentsScale)
         guard pixelWidth > 0, pixelHeight > 0 else { return }
 
-        // Reuse the existing texture when it's already the right size, otherwise allocate one.
         let image: CGImage
         if let existing = contents, existing.width == pixelWidth, existing.height == pixelHeight {
             image = existing
@@ -74,12 +68,8 @@ open class CAGradientLayer: CALayer {
 
         guard let target = GPU_GetTarget(image.rawPointer) else { return }
 
-        // `display()` runs mid-render-walk, where a clip rect (screen-space GL scissor) may be active and
-        // the model-view holds the layer's on-screen transform — both would wrongly affect our offscreen
-        // draw. Disable them, and crucially disable the target's CAMERA: the shader's transform is
-        // camera × projection × modelview, and image targets default to `use_camera = true` (inverted),
-        // which otherwise pushes our rect off the target. With the camera off + a plain ortho + identity
-        // model-view, the rect (0,0,w,h) maps 1:1 onto the whole texture.
+        // Disable the target's camera (inverted on image targets) so a plain ortho + identity maps our
+        // rect 1:1 onto the texture; otherwise the shader's camera × projection × modelview draws off-target.
         let savedClippingRect = UIScreen.main?.clippingRect
         UIScreen.main?.clippingRect = nil
         GPU_FlushBlitBuffer()
@@ -90,7 +80,7 @@ open class CAGradientLayer: CALayer {
         GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix(); GPU_LoadIdentity()
 
         GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
-        GPU_SetShapeBlending(false) // write the gradient's own straight alpha, don't blend into the cleared texture
+        GPU_SetShapeBlending(false)
         GPU_Clear(target)
 
         ShaderProgram.gradient.activate()
@@ -160,7 +150,7 @@ class GradientShaderProgram: ShaderProgram {
     ) {
         let count = Int32(min(colorStops.count, locationStops.count, GradientShaderProgram.maxStops))
 
-        // (minX, minY, height, width) — same packing the roundedRect/mask shaders expect.
+        // (minX, minY, height, width) — matches the roundedRect/mask uniform packing.
         var frameValues = [Float(rect.minX), Float(rect.minY), Float(rect.height), Float(rect.width)]
         GPU_SetUniformfv(rectFrame, 4, 1, &frameValues)
 

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -101,9 +101,7 @@ open class CAGradientLayer: CALayer {
             startPoint: startPoint,
             endPoint: endPoint,
             colors: _colors,
-            locations: locations.count >= colors.count
-                ? locations
-                : colors.indices.map { Float($0) / Float(max(colors.count - 1, 1)) }
+            locations: locations // already normalised to colors.count above
         )
         GPU_RectangleFilled(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)), color: UIColor.white.sdlColor)
 

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -1,4 +1,3 @@
-internal import SDL
 private import SDL_gpu
 
 open class CAGradientLayer: CALayer {
@@ -30,96 +29,25 @@ open class CAGradientLayer: CALayer {
         didSet { setNeedsDisplay() }
     }
 
+    /// Draw the gradient straight to the screen with the gradient shader — GPU-rasterised, with no
+    /// intermediate texture (the same mechanism `fill`/`shadow`/`roundedRect` use). Called by the render
+    /// walk (`CALayer+SDL`); `rect` is this layer's anchor-relative render rect.
     @_optimize(speed)
-    override open func display() {
-        super.display()
+    func drawGradient(into renderer: UIScreen, rect: CGRect) {
+        guard !colors.isEmpty else { return }
 
-        if bounds.width.isZero || bounds.height.isZero {
-            return
-        }
+        // Implicit, evenly-spaced stop locations when none (or too few) are provided — matches CAGradientLayer.
+        let stops = locations.count >= colors.count
+            ? locations
+            : colors.indices.map { Float($0) / Float(max(colors.count - 1, 1)) }
 
-        // Fill in implicit stop locations, and collapse the degenerate cases, exactly as before.
-        if locations.count < colors.count {
-            if colors.count == 1 {
-                backgroundColor = colors[0]
-                colors = []
-                locations = []
-            } else {
-                locations = colors.indices.map { Float($0) / Float(colors.count - 1) }
-            }
-        }
-
-        if colors.isEmpty {
-            contents = nil
-            return
-        }
-
-        // Rasterising on the GPU means we need a live renderer/context. `display()` only runs inside the
-        // render walk (`sdlRender`), where the context is current, but guard anyway so a stray call can't crash.
-        guard UIScreen.main != nil else { return }
-
-        let pixelWidth = Int(bounds.width * contentsScale)
-        let pixelHeight = Int(bounds.height * contentsScale)
-        guard pixelWidth > 0, pixelHeight > 0 else { return }
-
-        // Reuse the existing contents texture if it's already the right size, otherwise allocate one.
-        // We render *into* this texture, so both the visible-blit path and the mask-sampling path keep
-        // consuming `contents` exactly as they did with the old CPU surface.
-        let image: CGImage
-        if let existing = contents, existing.width == pixelWidth, existing.height == pixelHeight {
-            image = existing
-        } else {
-            guard let newImage = CGImage(width: pixelWidth, height: pixelHeight) else { return }
-            image = newImage
-        }
-
-        guard let target = GPU_GetTarget(image.rawPointer) else { return }
-
-        // `display()` runs mid-render-walk, where a clip rect may be active for masking. That clip is a
-        // global GL scissor set in *screen* coordinates — it would wrongly clip our offscreen draw (and
-        // silently blank it entirely when the texture's pixel space doesn't overlap the screen scissor).
-        // Disable it while we render into the texture, then restore it for the rest of the frame.
-        let savedClippingRect = UIScreen.main?.clippingRect
-        UIScreen.main?.clippingRect = nil
-
-        // SDL_gpu batches draws and reconfigures the render target lazily; flush the pending screen batch
-        // before switching to our offscreen target so the switch actually takes effect.
-        GPU_FlushBlitBuffer()
-
-        // SDL_gpu already installs the right coordinate system for a target when we start rendering into
-        // it (a plain draw with the matrices left untouched fills the target correctly). Overriding the
-        // projection/modelview ourselves drew nothing, so we deliberately DON'T touch the matrix stacks —
-        // we just clear and draw. `gpu_Vertex` (→ the shader's `absolutePixelPos`) then spans 0..w / 0..h.
-        // Force this target's viewport to its full area. SDL_gpu doesn't reliably reconfigure the viewport
-        // when we render to a second offscreen target within a frame, leaving the previous target's (screen-
-        // or sheet-sized) viewport active — under which this target's shape draw maps outside the FBO and
-        // nothing lands (while `GPU_Clear`, which ignores the viewport, still works).
-        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
-
-        GPU_SetShapeBlending(false) // write the gradient's own straight alpha instead of blending it
-        GPU_Clear(target)
-
-        ShaderProgram.gradient.activate()
-        ShaderProgram.gradient.set(
-            size: CGSize(width: pixelWidth, height: pixelHeight),
+        renderer.gradientFill(
+            rect,
             startPoint: startPoint,
             endPoint: endPoint,
             colors: _colors,
-            locations: locations
+            locations: stops
         )
-        GPU_RectangleFilled(
-            target,
-            GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)),
-            color: UIColor.white.sdlColor
-        )
-
-        ShaderProgram.deactivateAll()
-        // Flush our offscreen draw before the render walk resumes drawing to the screen target.
-        GPU_FlushBlitBuffer()
-        GPU_SetShapeBlending(true)
-        UIScreen.main?.clippingRect = savedClippingRect
-
-        contents = image
     }
 }
 
@@ -139,7 +67,7 @@ class GradientShaderProgram: ShaderProgram {
     // Keep in sync with `FragmentShader.maxGradientStops` in the shader source.
     static let maxStops = 16
 
-    private var gradientSize: ShaderVariableLocationID!
+    private var rectFrame: ShaderVariableLocationID!
     private var startPoint: ShaderVariableLocationID!
     private var endPoint: ShaderVariableLocationID!
     private var colorCount: ShaderVariableLocationID!
@@ -148,7 +76,7 @@ class GradientShaderProgram: ShaderProgram {
 
     fileprivate init() throws {
         try super.init(vertexShader: .common, fragmentShader: .gradient)
-        gradientSize = GPU_GetUniformLocation(programRef, "gradientSize")
+        rectFrame = GPU_GetUniformLocation(programRef, "rectFrame")
         startPoint = GPU_GetUniformLocation(programRef, "startPoint")
         endPoint = GPU_GetUniformLocation(programRef, "endPoint")
         colorCount = GPU_GetUniformLocation(programRef, "colorCount")
@@ -157,7 +85,7 @@ class GradientShaderProgram: ShaderProgram {
     }
 
     func set(
-        size: CGSize,
+        rect: CGRect,
         startPoint start: CGPoint,
         endPoint end: CGPoint,
         colors colorStops: [SIMD4<Float>],
@@ -165,8 +93,9 @@ class GradientShaderProgram: ShaderProgram {
     ) {
         let count = Int32(min(colorStops.count, locationStops.count, GradientShaderProgram.maxStops))
 
-        var sizeValues = [Float(size.width), Float(size.height)]
-        GPU_SetUniformfv(gradientSize, 2, 1, &sizeValues)
+        // (minX, minY, height, width) — same packing the roundedRect/mask shaders expect.
+        var frameValues = [Float(rect.minX), Float(rect.minY), Float(rect.height), Float(rect.width)]
+        GPU_SetUniformfv(rectFrame, 4, 1, &frameValues)
 
         var startValues = [Float(start.x), Float(start.y)]
         GPU_SetUniformfv(startPoint, 2, 1, &startValues)

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -5,18 +5,18 @@ open class CAGradientLayer: CALayer {
     public var colors: [CGColor] = [] {
         didSet {
             _colors = colors.map {
-                SIMD4<CGFloat>(
-                    x: CGFloat($0.redValue) / 255,
-                    y: CGFloat($0.greenValue) / 255,
-                    z: CGFloat($0.blueValue) / 255,
-                    w: CGFloat($0.alphaValue) / 255
+                SIMD4<Float>(
+                    x: Float($0.redValue) / 255,
+                    y: Float($0.greenValue) / 255,
+                    z: Float($0.blueValue) / 255,
+                    w: Float($0.alphaValue) / 255
                 )
             }
             setNeedsDisplay()
         }
     }
 
-    private var _colors: [SIMD4<CGFloat>] = []
+    private var _colors: [SIMD4<Float>] = []
 
     public var locations: [Float] = [] {
         didSet { setNeedsDisplay() }
@@ -38,6 +38,7 @@ open class CAGradientLayer: CALayer {
             return
         }
 
+        // Fill in implicit stop locations, and collapse the degenerate cases, exactly as before.
         if locations.count < colors.count {
             if colors.count == 1 {
                 backgroundColor = colors[0]
@@ -46,7 +47,6 @@ open class CAGradientLayer: CALayer {
             } else {
                 locations = colors.indices.map { Float($0) / Float(colors.count - 1) }
             }
-
         }
 
         if colors.isEmpty {
@@ -54,119 +54,132 @@ open class CAGradientLayer: CALayer {
             return
         }
 
-        let width: Int32
-        let height: Int32
+        // Rasterising on the GPU means we need a live renderer/context. `display()` only runs inside the
+        // render walk (`sdlRender`), where the context is current, but guard anyway so a stray call can't crash.
+        guard UIScreen.main != nil else { return }
 
-        if startPoint.x == endPoint.x {
-            width = 1
-            height = Int32(bounds.height * self.contentsScale)
-        } else if startPoint.y == endPoint.y {
-            width = Int32(bounds.width * self.contentsScale)
-            height = 1
+        let pixelWidth = Int(bounds.width * contentsScale)
+        let pixelHeight = Int(bounds.height * contentsScale)
+        guard pixelWidth > 0, pixelHeight > 0 else { return }
+
+        // Reuse the existing contents texture if it's already the right size, otherwise allocate one.
+        // We render *into* this texture, so both the visible-blit path and the mask-sampling path keep
+        // consuming `contents` exactly as they did with the old CPU surface.
+        let image: CGImage
+        if let existing = contents, existing.width == pixelWidth, existing.height == pixelHeight {
+            image = existing
         } else {
-            // pessimistic case where we need to fill the entire thing
-            width = Int32(bounds.width * self.contentsScale)
-            height = Int32(bounds.height * self.contentsScale)
+            guard let newImage = CGImage(width: pixelWidth, height: pixelHeight) else { return }
+            image = newImage
         }
 
-        guard let surface = SDL_CreateRGBSurfaceWithFormat(
-            0, // surface flags are always 0 in SDL2
-            width,
-            height,
-            32, // bit depth
-            UInt32(SDL_PIXELFORMAT_RGBA32)
-        ) else {
-            return
-        }
+        guard let target = GPU_GetTarget(image.rawPointer) else { return }
 
-        SDL_LockSurface(surface)
+        // `display()` runs mid-render-walk, where a clip rect may be active for masking. That clip is a
+        // global GL scissor set in *screen* coordinates — it would wrongly clip our offscreen draw (and
+        // silently blank it entirely when the texture's pixel space doesn't overlap the screen scissor).
+        // Disable it while we render into the texture, then restore it for the rest of the frame.
+        let savedClippingRect = UIScreen.main?.clippingRect
+        UIScreen.main?.clippingRect = nil
 
-        let startPoint = SIMD2(x: self.startPoint.x, y: self.startPoint.y)
-        let endPoint = SIMD2(x: self.endPoint.x, y: self.endPoint.y)
+        // SDL_gpu batches draws and reconfigures the render target lazily; flush the pending screen batch
+        // before switching to our offscreen target so the switch actually takes effect.
+        GPU_FlushBlitBuffer()
 
-        for y in 0 ..< Int(height) {
-            let pixelPosY = y * Int(surface.pointee.pitch)
+        // SDL_gpu already installs the right coordinate system for a target when we start rendering into
+        // it (a plain draw with the matrices left untouched fills the target correctly). Overriding the
+        // projection/modelview ourselves drew nothing, so we deliberately DON'T touch the matrix stacks —
+        // we just clear and draw. `gpu_Vertex` (→ the shader's `absolutePixelPos`) then spans 0..w / 0..h.
+        // Force this target's viewport to its full area. SDL_gpu doesn't reliably reconfigure the viewport
+        // when we render to a second offscreen target within a frame, leaving the previous target's (screen-
+        // or sheet-sized) viewport active — under which this target's shape draw maps outside the FBO and
+        // nothing lands (while `GPU_Clear`, which ignores the viewport, still works).
+        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
 
-            for x in 0 ..< Int(width) {
-                let pixel = surface.pointee.pixels.assumingMemoryBound(to: UInt8.self)
-                    .advanced(by: pixelPosY)
-                    .advanced(by: x * Int(surface.pointee.format.pointee.BytesPerPixel))
+        GPU_SetShapeBlending(false) // write the gradient's own straight alpha instead of blending it
+        GPU_Clear(target)
 
-                let p = SIMD2(x: CGFloat(x) / bounds.width, y: CGFloat(y) / bounds.height)
+        ShaderProgram.gradient.activate()
+        ShaderProgram.gradient.set(
+            size: CGSize(width: pixelWidth, height: pixelHeight),
+            startPoint: startPoint,
+            endPoint: endPoint,
+            colors: _colors,
+            locations: locations
+        )
+        GPU_RectangleFilled(
+            target,
+            GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)),
+            color: UIColor.white.sdlColor
+        )
 
-                // Direction of gradient line
-                let dir = endPoint - startPoint
-                let len2 = dot(dir, dir)
+        ShaderProgram.deactivateAll()
+        // Flush our offscreen draw before the render walk resumes drawing to the screen target.
+        GPU_FlushBlitBuffer()
+        GPU_SetShapeBlending(true)
+        UIScreen.main?.clippingRect = savedClippingRect
 
-                var t: CGFloat = 0.0
-                if len2 > 0.00001 {
-                    // Project (p - startPoint) onto the gradient direction
-                    t = dot(p - startPoint, dir) / len2
-                }
-
-                t = max(0.0, min(t, 1.0))
-                let color = sampleGradient(t)
-
-                let normalized = color * 255
-                pixel[0] = UInt8(clamping: Int(normalized.x))
-                pixel[1] = UInt8(clamping: Int(normalized.y))
-                pixel[2] = UInt8(clamping: Int(normalized.z))
-                pixel[3] = UInt8(clamping: Int(normalized.w))
-            }
-        }
-
-        SDL_UnlockSurface(surface)
-
-        if
-            let contents,
-            contents.width != Int(bounds.width) ||
-            contents.height != Int(bounds.height)
-        {
-            contents.replacePixels(
-                with: surface.pointee.pixels.assumingMemoryBound(to: UInt8.self),
-                bytesPerPixel: Int(surface.pointee.format.pointee.BytesPerPixel)
-            )
-        } else {
-            contents = CGImage(surface: surface)
-        }
-    }
-
-    @_optimize(speed)
-    func sampleGradient(_ position: CGFloat) -> SIMD4<CGFloat> {
-        precondition(colors.count >= 2)
-        precondition(locations.count >= 2)
-
-        let t = Float(max(0.0, min(position, 1.0)))
-
-        if t <= locations.first! {
-            return _colors.first!
-        } else if t >= locations.last! {
-            return _colors.last!
-        }
-
-        // Find stops [i, i+1] containing t
-        for i in 0 ..< (colors.count - 1) {
-            let loc0 = locations[i]
-            let loc1 = locations[i + 1]
-
-            if t >= loc0 && t <= loc1 {
-                let localT = (t - loc0) / (loc1 - loc0)
-                return mix(_colors[i], _colors[i + 1], t: CGFloat(localT))
-            }
-        }
-
-        return _colors.last!
+        contents = image
     }
 }
 
 
-// GLSL-style mix for SIMD4
-@inline(__always)
-func mix(_ a: SIMD4<CGFloat>, _ b: SIMD4<CGFloat>, t: CGFloat) -> SIMD4<CGFloat> {
-    return a + (b - a) * t
+extension ShaderProgram {
+    private static var _gradient: GradientShaderProgram?
+    static var gradient: GradientShaderProgram {
+        if let existing = _gradient { return existing }
+        let program = try! GradientShaderProgram()
+        _gradient = program
+        return program
+    }
+    static func invalidateGradient() { _gradient = nil }
 }
 
-@inline(__always)
-func dot(_ a: SIMD2<CGFloat>, _ b: SIMD2<CGFloat>) -> CGFloat {
-    return a.x * b.x + a.y * b.y
+class GradientShaderProgram: ShaderProgram {
+    // Keep in sync with `FragmentShader.maxGradientStops` in the shader source.
+    static let maxStops = 16
+
+    private var gradientSize: ShaderVariableLocationID!
+    private var startPoint: ShaderVariableLocationID!
+    private var endPoint: ShaderVariableLocationID!
+    private var colorCount: ShaderVariableLocationID!
+    private var colors: ShaderVariableLocationID!
+    private var locations: ShaderVariableLocationID!
+
+    fileprivate init() throws {
+        try super.init(vertexShader: .common, fragmentShader: .gradient)
+        gradientSize = GPU_GetUniformLocation(programRef, "gradientSize")
+        startPoint = GPU_GetUniformLocation(programRef, "startPoint")
+        endPoint = GPU_GetUniformLocation(programRef, "endPoint")
+        colorCount = GPU_GetUniformLocation(programRef, "colorCount")
+        colors = GPU_GetUniformLocation(programRef, "colors")
+        locations = GPU_GetUniformLocation(programRef, "locations")
+    }
+
+    func set(
+        size: CGSize,
+        startPoint start: CGPoint,
+        endPoint end: CGPoint,
+        colors colorStops: [SIMD4<Float>],
+        locations locationStops: [Float]
+    ) {
+        let count = Int32(min(colorStops.count, locationStops.count, GradientShaderProgram.maxStops))
+
+        var sizeValues = [Float(size.width), Float(size.height)]
+        GPU_SetUniformfv(gradientSize, 2, 1, &sizeValues)
+
+        var startValues = [Float(start.x), Float(start.y)]
+        GPU_SetUniformfv(startPoint, 2, 1, &startValues)
+
+        var endValues = [Float(end.x), Float(end.y)]
+        GPU_SetUniformfv(endPoint, 2, 1, &endValues)
+
+        GPU_SetUniformi(colorCount, count)
+
+        var colorValues = colorStops.prefix(Int(count)).flatMap { [$0.x, $0.y, $0.z, $0.w] }
+        GPU_SetUniformfv(colors, 4, count, &colorValues)
+
+        var locationValues = Array(locationStops.prefix(Int(count)))
+        GPU_SetUniformfv(locations, 1, count, &locationValues)
+    }
 }

--- a/Sources/CAGradientLayer.swift
+++ b/Sources/CAGradientLayer.swift
@@ -52,7 +52,7 @@ open class CAGradientLayer: CALayer {
             return
         }
 
-        guard UIScreen.main != nil else { return }
+        guard let renderer = UIScreen.main else { return }
 
         let pixelWidth = Int(bounds.width * contentsScale)
         let pixelHeight = Int(bounds.height * contentsScale)
@@ -66,44 +66,18 @@ open class CAGradientLayer: CALayer {
             image = newImage
         }
 
-        guard let target = GPU_GetTarget(image.rawPointer) else { return }
-
-        // This runs mid-parent-render-pass, so save every piece of shared GL state we touch and restore it
-        // via `defer` — that way any early return added below can't leak state into the outer pass.
-        let savedClippingRect = UIScreen.main?.clippingRect
-        UIScreen.main?.clippingRect = nil
-        GPU_FlushBlitBuffer()
-        GPU_MatrixMode(GPU_PROJECTION); GPU_PushMatrix()
-        GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix()
-        GPU_SetShapeBlending(false)
-        defer {
-            ShaderProgram.deactivateAll()
-            GPU_FlushBlitBuffer()
-            GPU_MatrixMode(GPU_MODELVIEW); GPU_PopMatrix()
-            GPU_MatrixMode(GPU_PROJECTION); GPU_PopMatrix()
-            GPU_MatrixMode(GPU_MODELVIEW) // leave mode as the outer render pass expects it
-            GPU_SetShapeBlending(true)
-            UIScreen.main?.clippingRect = savedClippingRect
+        let rect = GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight))
+        renderer.drawIntoTexture(image) { target in
+            ShaderProgram.gradient.activate()
+            ShaderProgram.gradient.set(
+                rect: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight),
+                startPoint: startPoint,
+                endPoint: endPoint,
+                colors: _colors,
+                locations: locations // already normalised to colors.count above
+            )
+            GPU_RectangleFilled(target, rect, color: UIColor.white.sdlColor)
         }
-
-        // Disable the target's camera (inverted on image targets) so a plain ortho + identity maps our
-        // rect 1:1 onto the texture; otherwise the shader's camera × projection × modelview draws off-target.
-        GPU_EnableCamera(target, false)
-        GPU_MatrixMode(GPU_PROJECTION); GPU_LoadIdentity()
-        GPU_Ortho(0, Float(pixelWidth), Float(pixelHeight), 0, -1, 1)
-        GPU_MatrixMode(GPU_MODELVIEW); GPU_LoadIdentity()
-        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)))
-        GPU_Clear(target)
-
-        ShaderProgram.gradient.activate()
-        ShaderProgram.gradient.set(
-            rect: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight),
-            startPoint: startPoint,
-            endPoint: endPoint,
-            colors: _colors,
-            locations: locations // already normalised to colors.count above
-        )
-        GPU_RectangleFilled(target, GPU_Rect(x: 0, y: 0, w: Float(pixelWidth), h: Float(pixelHeight)), color: UIColor.white.sdlColor)
 
         contents = image
     }

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -67,7 +67,10 @@ extension CALayer {
             renderer.clippingRect =
                 renderer.clippingRect?.intersection(maskAbsoluteFrame) ?? maskAbsoluteFrame
 
-            // The mask isn't in the sublayer tree, so render it here to populate its `contents`.
+            // The mask isn't in the sublayer tree, so render it here to populate its `contents`. Only the
+            // mask's `contents` are honoured (it's `display()`d, not `sdlRender`d) — a mask relying on its own
+            // backgroundColor/border/sublayers is NOT applied. Fine for image/CAGradientLayer masks; this is
+            // not full-subtree masking.
             if mask.contentsScale != contentsScale { mask.contentsScale = contentsScale }
             if mask.needsDisplay() { mask.display(); mask._needsDisplay = false }
 

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -97,12 +97,6 @@ extension CALayer {
             )
         }
 
-        // A CAGradientLayer draws its gradient directly to the screen here (GPU-rasterised, no texture),
-        // on top of its own backgroundColor and beneath any sublayers.
-        if let gradientLayer = self as? CAGradientLayer {
-            gradientLayer.drawGradient(into: renderer, rect: renderedBoundsRelativeToAnchorPoint)
-        }
-
         if borderWidth > 0 {
             renderer.outline(
                 renderedBoundsRelativeToAnchorPoint,

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -67,9 +67,28 @@ extension CALayer {
             renderer.clippingRect =
                 renderer.clippingRect?.intersection(maskAbsoluteFrame) ?? maskAbsoluteFrame
 
+            // A mask layer isn't part of the `sublayers` tree, so the render walk never renders it and thus
+            // never populates its `contents`. Drive its `display()` here (mirroring how a layer displays
+            // itself below) so masks that generate their own contents — e.g. `CAGradientLayer` — actually
+            // produce a texture to sample. Match our contentsScale so the mask is rendered at screen resolution.
+            if mask.contentsScale != contentsScale {
+                mask.contentsScale = contentsScale
+            }
+            if mask.needsDisplay() {
+                mask.display()
+                mask._needsDisplay = false
+            }
+
             if let maskContents = mask.contents {
+                // The mask shader maps `absolutePixelPos` (the vertex position of the content blit, which
+                // spans this layer's anchor-relative render rect — `[-anchor*size … (1-anchor)*size]`) into
+                // the mask's [0,1] texture space via `(pos - frame.origin) / frame.size`. So the frame must
+                // be given in that same anchor-relative space: the mask's own frame within the layer, shifted
+                // by the layer's anchor offset. (Passing `mask.bounds`, origin 0,0, sampled only half the
+                // mask for the default 0.5 anchor.)
+                let maskShaderFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin)
                 ShaderProgram.mask.activate() // must activate before setting parameters (below)!
-                ShaderProgram.mask.set(maskImage: maskContents, frame: mask.bounds)
+                ShaderProgram.mask.set(maskImage: maskContents, frame: maskShaderFrame)
             }
         }
 

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -67,28 +67,9 @@ extension CALayer {
             renderer.clippingRect =
                 renderer.clippingRect?.intersection(maskAbsoluteFrame) ?? maskAbsoluteFrame
 
-            // A mask layer isn't part of the `sublayers` tree, so the render walk never renders it and thus
-            // never populates its `contents`. Drive its `display()` here (mirroring how a layer displays
-            // itself below) so masks that generate their own contents — e.g. `CAGradientLayer` — actually
-            // produce a texture to sample. Match our contentsScale so the mask is rendered at screen resolution.
-            if mask.contentsScale != contentsScale {
-                mask.contentsScale = contentsScale
-            }
-            if mask.needsDisplay() {
-                mask.display()
-                mask._needsDisplay = false
-            }
-
             if let maskContents = mask.contents {
-                // The mask shader maps `absolutePixelPos` (the vertex position of the content blit, which
-                // spans this layer's anchor-relative render rect — `[-anchor*size … (1-anchor)*size]`) into
-                // the mask's [0,1] texture space via `(pos - frame.origin) / frame.size`. So the frame must
-                // be given in that same anchor-relative space: the mask's own frame within the layer, shifted
-                // by the layer's anchor offset. (Passing `mask.bounds`, origin 0,0, sampled only half the
-                // mask for the default 0.5 anchor.)
-                let maskShaderFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin)
                 ShaderProgram.mask.activate() // must activate before setting parameters (below)!
-                ShaderProgram.mask.set(maskImage: maskContents, frame: maskShaderFrame)
+                ShaderProgram.mask.set(maskImage: maskContents, frame: mask.bounds)
             }
         }
 
@@ -114,6 +95,12 @@ extension CALayer {
                 with: backgroundColor.withAlphaComponent(CGFloat(backgroundColorOpacity)),
                 cornerRadius: cornerRadius
             )
+        }
+
+        // A CAGradientLayer draws its gradient directly to the screen here (GPU-rasterised, no texture),
+        // on top of its own backgroundColor and beneath any sublayers.
+        if let gradientLayer = self as? CAGradientLayer {
+            gradientLayer.drawGradient(into: renderer, rect: renderedBoundsRelativeToAnchorPoint)
         }
 
         if borderWidth > 0 {

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -67,9 +67,15 @@ extension CALayer {
             renderer.clippingRect =
                 renderer.clippingRect?.intersection(maskAbsoluteFrame) ?? maskAbsoluteFrame
 
+            // The mask isn't in the sublayer tree, so render it here to populate its `contents`.
+            if mask.contentsScale != contentsScale { mask.contentsScale = contentsScale }
+            if mask.needsDisplay() { mask.display(); mask._needsDisplay = false }
+
             if let maskContents = mask.contents {
+             
+                let maskShaderFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin)
                 ShaderProgram.mask.activate() // must activate before setting parameters (below)!
-                ShaderProgram.mask.set(maskImage: maskContents, frame: mask.bounds)
+                ShaderProgram.mask.set(maskImage: maskContents, frame: maskShaderFrame)
             }
         }
 

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -72,10 +72,12 @@ extension CALayer {
             if mask.needsDisplay() { mask.display(); mask._needsDisplay = false }
 
             if let maskContents = mask.contents {
-             
+                // Use the image-sampling mask shader only when this layer has its own texture to mask;
+                // otherwise the colour-masking shader (unchanged) handles solid-colour layers.
+                let maskProgram = contents != nil ? ShaderProgram.maskImage : ShaderProgram.mask
                 let maskShaderFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin)
-                ShaderProgram.mask.activate() // must activate before setting parameters (below)!
-                ShaderProgram.mask.set(maskImage: maskContents, frame: maskShaderFrame)
+                maskProgram.activate() // must activate before setting parameters (below)!
+                maskProgram.set(maskImage: maskContents, frame: maskShaderFrame)
             }
         }
 

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -190,7 +190,7 @@ extension FragmentShader {
 
         \(fragColorDefinition)
 
-        uniform vec2 gradientSize;
+        uniform vec4 rectFrame; // (x, y, height, width) — same packing as roundedRect/mask
         uniform vec2 startPoint;
         uniform vec2 endPoint;
         uniform int colorCount;
@@ -199,7 +199,9 @@ extension FragmentShader {
 
         void main(void)
         {
-            vec2 p = absolutePixelPos / gradientSize;
+            // Normalise the fragment's position within the drawn rect to [0,1] (drawn straight to screen,
+            // so `absolutePixelPos` is in the layer's anchor-relative space; `rectFrame` maps it back).
+            vec2 p = (absolutePixelPos - vec2(rectFrame.x, rectFrame.y)) / vec2(rectFrame.w, rectFrame.z);
 
             vec2 dir = endPoint - startPoint;
             float len2 = dot(dir, dir);

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -26,11 +26,13 @@ extension VertexShader {
 
         \(`out`) vec4 originalColour;
         \(`out`) vec2 absolutePixelPos;
+        \(`out`) vec2 texCoord;
 
         void main(void)
         {
             originalColour = gpu_Color;
             absolutePixelPos = vec2(gpu_Vertex.xy);
+            texCoord = gpu_TexCoord;
             gl_Position = gpu_ModelViewProjectionMatrix * vec4(gpu_Vertex, 1.0);
         }
         """
@@ -79,11 +81,13 @@ extension FragmentShader {
     private static let maskColourWithImageSource = """
         \(`in`) vec4 originalColour;
         \(`in`) vec2 absolutePixelPos;
+        \(`in`) vec2 texCoord;
 
         \(fragColorDefinition)
 
         uniform vec4 maskFrame;
         uniform sampler2D maskTexture;
+        uniform sampler2D tex; // the masked layer's own contents (blit image, texture unit 0)
 
         void main(void)
         {
@@ -93,7 +97,8 @@ extension FragmentShader {
             );
 
             vec4 maskColour = \(texture)(maskTexture, maskCoordinate);
-            \(fragColor) = vec4(originalColour.rgb, originalColour.a * maskColour.a);
+            vec4 base = \(texture)(tex, texCoord) * originalColour;
+            \(fragColor) = vec4(base.rgb, base.a * maskColour.a);
         }
         """
 

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -175,13 +175,7 @@ extension FragmentShader {
         }
         """
 
-    // Axis-aligned / arbitrary-angle colour gradient, evaluated per-fragment on the GPU. This is the
-    // shader equivalent of `CAGradientLayer`'s former CPU pixel loop: `t` is the position along the
-    // gradient line (`startPoint` -> `endPoint`, both in unit coordinates) projected from the fragment's
-    // normalised position, then colours are interpolated between the surrounding stops. Straight
-    // (non-premultiplied) RGBA is written so the result works both as a blitted layer and as a mask
-    // (whose alpha channel is what the mask shader samples). `MAX_GRADIENT_STOPS` bounds the arrays;
-    // keep it in sync with `GradientShaderProgram.maxStops`.
+    // Per-fragment colour gradient (CAGradientLayer). Keep in sync with `GradientShaderProgram.maxStops`.
     static let maxGradientStops = 16
     private static let gradientSource = """
         #define MAX_GRADIENT_STOPS \(maxGradientStops)

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -193,8 +193,6 @@ extension FragmentShader {
 
         void main(void)
         {
-            // Normalise the fragment's position within the drawn rect to [0,1] (drawn straight to screen,
-            // so `absolutePixelPos` is in the layer's anchor-relative space; `rectFrame` maps it back).
             vec2 p = (absolutePixelPos - vec2(rectFrame.x, rectFrame.y)) / vec2(rectFrame.w, rectFrame.z);
 
             vec2 dir = endPoint - startPoint;

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -47,6 +47,14 @@ extension FragmentShader {
         return shader
     }
 
+    private static var _maskImageWithImage: FragmentShader?
+    static var maskImageWithImage: FragmentShader {
+        if let existing = _maskImageWithImage { return existing }
+        let shader = try! FragmentShader(source: maskImageWithImageSource)
+        _maskImageWithImage = shader
+        return shader
+    }
+
     private static var _roundedRect: FragmentShader?
     static var roundedRect: FragmentShader {
         if let existing = _roundedRect { return existing }
@@ -73,12 +81,36 @@ extension FragmentShader {
 
     static func invalidateAll() {
         _maskColourWithImage = nil
+        _maskImageWithImage = nil
         _roundedRect = nil
         _roundedRectShadow = nil
         _gradient = nil
     }
 
+    // Masks a solid (per-vertex) colour by an image's alpha.
     private static let maskColourWithImageSource = """
+        \(`in`) vec4 originalColour;
+        \(`in`) vec2 absolutePixelPos;
+
+        \(fragColorDefinition)
+
+        uniform vec4 maskFrame;
+        uniform sampler2D maskTexture;
+
+        void main(void)
+        {
+            vec2 maskCoordinate = vec2(
+                ((absolutePixelPos.x - maskFrame.x) / maskFrame.w),
+                ((absolutePixelPos.y - maskFrame.y) / maskFrame.z) // z == height
+            );
+
+            vec4 maskColour = \(texture)(maskTexture, maskCoordinate);
+            \(fragColor) = vec4(originalColour.rgb, originalColour.a * maskColour.a);
+        }
+        """
+
+    // Masks a textured layer (samples its own contents `tex`, unit 0) by an image's alpha.
+    private static let maskImageWithImageSource = """
         \(`in`) vec4 originalColour;
         \(`in`) vec2 absolutePixelPos;
         \(`in`) vec2 texCoord;
@@ -87,7 +119,7 @@ extension FragmentShader {
 
         uniform vec4 maskFrame;
         uniform sampler2D maskTexture;
-        uniform sampler2D tex; // the masked layer's own contents (blit image, texture unit 0)
+        uniform sampler2D tex;
 
         void main(void)
         {

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -237,20 +237,18 @@ extension FragmentShader {
             float t = len2 > 0.00001 ? dot(p - startPoint, dir) / len2 : 0.0;
             t = clamp(t, 0.0, 1.0);
 
+            // Constant loop bound and loop-index-only array access (no uniform-derived indices) so this
+            // stays a valid constant-index-expression under GLSL ES 2.0. Each segment whose start `t` has
+            // passed overwrites `color`; later segments win, so after the loop `color` holds the right stop
+            // (colours[0] below the first stop, the last colour at/above the final stop).
             vec4 color = colors[0];
-            if (t <= locations[0]) {
-                color = colors[0];
-            } else if (t >= locations[colorCount - 1]) {
-                color = colors[colorCount - 1];
-            } else {
-                for (int i = 0; i < colorCount - 1; i++) {
-                    float loc0 = locations[i];
-                    float loc1 = locations[i + 1];
-                    if (t >= loc0 && t <= loc1) {
-                        float localT = (t - loc0) / max(loc1 - loc0, 0.000001);
-                        color = mix(colors[i], colors[i + 1], localT);
-                        break;
-                    }
+            for (int i = 0; i < MAX_GRADIENT_STOPS - 1; i++) {
+                if (i + 1 >= colorCount) break;
+                float loc0 = locations[i];
+                float loc1 = locations[i + 1];
+                if (t >= loc0) {
+                    float localT = clamp((t - loc0) / max(loc1 - loc0, 0.000001), 0.0, 1.0);
+                    color = mix(colors[i], colors[i + 1], localT);
                 }
             }
 

--- a/Sources/MaskingShaders.swift
+++ b/Sources/MaskingShaders.swift
@@ -61,10 +61,19 @@ extension FragmentShader {
         return shader
     }
 
+    private static var _gradient: FragmentShader?
+    static var gradient: FragmentShader {
+        if let existing = _gradient { return existing }
+        let shader = try! FragmentShader(source: gradientSource)
+        _gradient = shader
+        return shader
+    }
+
     static func invalidateAll() {
         _maskColourWithImage = nil
         _roundedRect = nil
         _roundedRectShadow = nil
+        _gradient = nil
     }
 
     private static let maskColourWithImageSource = """
@@ -163,6 +172,58 @@ extension FragmentShader {
             float alpha = 1.0 - smoothstep(-blur, blur, d);
 
             \(fragColor) = vec4(originalColour.rgb, originalColour.a * alpha);
+        }
+        """
+
+    // Axis-aligned / arbitrary-angle colour gradient, evaluated per-fragment on the GPU. This is the
+    // shader equivalent of `CAGradientLayer`'s former CPU pixel loop: `t` is the position along the
+    // gradient line (`startPoint` -> `endPoint`, both in unit coordinates) projected from the fragment's
+    // normalised position, then colours are interpolated between the surrounding stops. Straight
+    // (non-premultiplied) RGBA is written so the result works both as a blitted layer and as a mask
+    // (whose alpha channel is what the mask shader samples). `MAX_GRADIENT_STOPS` bounds the arrays;
+    // keep it in sync with `GradientShaderProgram.maxStops`.
+    static let maxGradientStops = 16
+    private static let gradientSource = """
+        #define MAX_GRADIENT_STOPS \(maxGradientStops)
+
+        \(`in`) vec2 absolutePixelPos;
+
+        \(fragColorDefinition)
+
+        uniform vec2 gradientSize;
+        uniform vec2 startPoint;
+        uniform vec2 endPoint;
+        uniform int colorCount;
+        uniform vec4 colors[MAX_GRADIENT_STOPS];
+        uniform float locations[MAX_GRADIENT_STOPS];
+
+        void main(void)
+        {
+            vec2 p = absolutePixelPos / gradientSize;
+
+            vec2 dir = endPoint - startPoint;
+            float len2 = dot(dir, dir);
+            float t = len2 > 0.00001 ? dot(p - startPoint, dir) / len2 : 0.0;
+            t = clamp(t, 0.0, 1.0);
+
+            vec4 color = colors[0];
+            if (t <= locations[0]) {
+                color = colors[0];
+            } else if (t >= locations[colorCount - 1]) {
+                color = colors[colorCount - 1];
+            } else {
+                for (int i = 0; i < colorCount - 1; i++) {
+                    float loc0 = locations[i];
+                    float loc1 = locations[i + 1];
+                    if (t >= loc0 && t <= loc1) {
+                        float localT = (t - loc0) / max(loc1 - loc0, 0.000001);
+                        color = mix(colors[i], colors[i + 1], localT);
+                        break;
+                    }
+                }
+            }
+
+            \(fragColor) = color;
         }
         """
 }

--- a/Sources/ShaderProgram+mask.swift
+++ b/Sources/ShaderProgram+mask.swift
@@ -8,24 +8,33 @@
 
 internal import SDL_gpu
 
-extension ShaderProgram {
+extension ShaderProgram { 
     private static var _mask: MaskShaderProgram?
     static var mask: MaskShaderProgram {
         if let existing = _mask { return existing }
-        let program = try! MaskShaderProgram()
+        let program = try! MaskShaderProgram(fragmentShader: .maskColourWithImage)
         _mask = program
         return program
     }
-    static func invalidateMask() { _mask = nil }
+
+    // Masks a textured layer (samples its own contents) by an image's alpha.
+    private static var _maskImage: MaskShaderProgram?
+    static var maskImage: MaskShaderProgram {
+        if let existing = _maskImage { return existing }
+        let program = try! MaskShaderProgram(fragmentShader: .maskImageWithImage)
+        _maskImage = program
+        return program
+    }
+
+    static func invalidateMask() { _mask = nil; _maskImage = nil }
 }
 
 class MaskShaderProgram: ShaderProgram {
     private var maskFrame: UniformVariable!
     private var maskTexture: UniformVariable!
 
-    // we only need one MaskShaderProgram, which we can / should treat as a singleton
-    fileprivate init() throws {
-        try super.init(vertexShader: .common, fragmentShader: .maskColourWithImage)
+    fileprivate init(fragmentShader: FragmentShader) throws {
+        try super.init(vertexShader: .common, fragmentShader: fragmentShader)
         maskFrame = UniformVariable("maskFrame", in: programRef)
         maskTexture = UniformVariable("maskTexture", in: programRef)
     }

--- a/Sources/ShaderProgram+mask.swift
+++ b/Sources/ShaderProgram+mask.swift
@@ -32,15 +32,21 @@ extension ShaderProgram {
 class MaskShaderProgram: ShaderProgram {
     private var maskFrame: UniformVariable!
     private var maskTexture: UniformVariable!
+    // The base-image sampler (`tex`) — only present in the image-mask shader; -1 otherwise.
+    private var texLocation: ShaderVariableLocationID = -1
 
     fileprivate init(fragmentShader: FragmentShader) throws {
         try super.init(vertexShader: .common, fragmentShader: fragmentShader)
         maskFrame = UniformVariable("maskFrame", in: programRef)
         maskTexture = UniformVariable("maskTexture", in: programRef)
+        texLocation = GPU_GetUniformLocation(programRef, "tex")
     }
 
     func set(maskImage: CGImage, frame: CGRect) {
-        maskFrame.set(frame)
+        maskFrame.set(frame)               // maskTexture is bound to texture unit 1 (see UniformVariable.set)
         maskTexture.set(maskImage)
+        // Bind the base-image sampler to unit 0 explicitly — the unit SDL_gpu blits the layer's contents
+        // into — rather than relying on the GLSL default. (Program must be active; the caller activates it.)
+        if texLocation != -1 { GPU_SetUniformi(texLocation, 0) }
     }
 }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -70,6 +70,24 @@ extension UIScreen {
         try throwOnErrors(ofType: [GPU_ERROR_USER_ERROR])
     }
 
+    /// Draw a colour gradient straight into `rect` on the GPU (no intermediate texture) using the gradient
+    /// shader. `rect` is in the layer's anchor-relative coordinate space (same as `fill`). The gradient's
+    /// own alpha blends over whatever is already on screen (shape blending is on), so a `paper → transparent`
+    /// gradient occludes on one side and crossfades into the content behind it on the other.
+    func gradientFill(
+        _ rect: CGRect,
+        startPoint: CGPoint,
+        endPoint: CGPoint,
+        colors: [SIMD4<Float>],
+        locations: [Float]
+    ) {
+        let previousProgram = ShaderProgram.currentlyActive
+        ShaderProgram.gradient.activate()
+        ShaderProgram.gradient.set(rect: rect, startPoint: startPoint, endPoint: endPoint, colors: colors, locations: locations)
+        GPU_RectangleFilled(rawPointer, gpuRect(rect), color: UIColor.white.sdlColor)
+        restoreShaderProgram(previousProgram)
+    }
+
     func setShapeBlending(_ newValue: Bool) {
         GPU_SetShapeBlending(newValue)
     }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -70,24 +70,6 @@ extension UIScreen {
         try throwOnErrors(ofType: [GPU_ERROR_USER_ERROR])
     }
 
-    /// Draw a colour gradient straight into `rect` on the GPU (no intermediate texture) using the gradient
-    /// shader. `rect` is in the layer's anchor-relative coordinate space (same as `fill`). The gradient's
-    /// own alpha blends over whatever is already on screen (shape blending is on), so a `paper → transparent`
-    /// gradient occludes on one side and crossfades into the content behind it on the other.
-    func gradientFill(
-        _ rect: CGRect,
-        startPoint: CGPoint,
-        endPoint: CGPoint,
-        colors: [SIMD4<Float>],
-        locations: [Float]
-    ) {
-        let previousProgram = ShaderProgram.currentlyActive
-        ShaderProgram.gradient.activate()
-        ShaderProgram.gradient.set(rect: rect, startPoint: startPoint, endPoint: endPoint, colors: colors, locations: locations)
-        GPU_RectangleFilled(rawPointer, gpuRect(rect), color: UIColor.white.sdlColor)
-        restoreShaderProgram(previousProgram)
-    }
-
     func setShapeBlending(_ newValue: Bool) {
         GPU_SetShapeBlending(newValue)
     }

--- a/Sources/UIScreen+render.swift
+++ b/Sources/UIScreen+render.swift
@@ -82,6 +82,45 @@ extension UIScreen {
         GPU_Clear(rawPointer)
     }
 
+    /// Draws `body` into `image` as an offscreen render target, then restores all touched GL state.
+    /// Used to (re)build a layer's cached `contents` (e.g. `CAGradientLayer`).
+    ///
+    /// This runs *inside* the main render pass, where the projection/model-view and clip are configured
+    /// for the screen. Rendering into a texture needs its own coordinate system, so we install an ortho +
+    /// identity sized to the texture (and disable the target's camera, which is Y-inverted on image targets)
+    /// so `body`'s draw maps 1:1 onto it — then pop everything back so the outer pass is untouched. The
+    /// save/restore is `defer`-based so an early return in `body` can't leak state into the outer pass.
+    @MainActor
+    func drawIntoTexture(_ image: CGImage, _ body: (_ target: UnsafeMutablePointer<GPU_Target>) -> Void) {
+        guard let target = GPU_GetTarget(image.rawPointer) else { return }
+        let width = Float(image.width), height = Float(image.height)
+
+        let savedClippingRect = clippingRect
+        clippingRect = nil
+        GPU_FlushBlitBuffer()
+        GPU_MatrixMode(GPU_PROJECTION); GPU_PushMatrix()
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_PushMatrix()
+        GPU_SetShapeBlending(false) // write the layer's own straight alpha, don't blend into the cleared texture
+        defer {
+            ShaderProgram.deactivateAll()
+            GPU_FlushBlitBuffer()
+            GPU_MatrixMode(GPU_MODELVIEW); GPU_PopMatrix()
+            GPU_MatrixMode(GPU_PROJECTION); GPU_PopMatrix()
+            GPU_MatrixMode(GPU_MODELVIEW) // leave the mode as the outer render pass expects it
+            GPU_SetShapeBlending(true)
+            clippingRect = savedClippingRect
+        }
+
+        GPU_EnableCamera(target, false)
+        GPU_MatrixMode(GPU_PROJECTION); GPU_LoadIdentity()
+        GPU_Ortho(0, width, height, 0, -1, 1)
+        GPU_MatrixMode(GPU_MODELVIEW); GPU_LoadIdentity()
+        GPU_SetViewport(target, GPU_Rect(x: 0, y: 0, w: width, h: height))
+        GPU_Clear(target)
+
+        body(target)
+    }
+
     func fill(_ rect: CGRect, with color: UIColor, cornerRadius: CGFloat) {
         if cornerRadius >= 1 {
             let snappedRect = pixelSnapped(rect)

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -145,6 +145,7 @@ public final class UIScreen {
             ShaderProgram.invalidateRoundedRect()
             ShaderProgram.invalidateShadow()
             ShaderProgram.invalidateMask()
+            ShaderProgram.invalidateGradient()
             FragmentShader.invalidateAll()
             VertexShader.invalidateAll()
         }


### PR DESCRIPTION
Fixes # https://app.asana.com/1/2883569378809/project/1206248656749420/task/1216650934897706

**Type of change:** Update

## Motivation (current vs expected behavior)

We want to rasterize the gradient via the GPU, rather than the nested pixel loop the status quo was doing.
The general idea is to rasterize the gradient once into a cached texture (until the panel itself changes) and then copy/blitting this for each frame.

<img width="662" height="327" alt="Screenshot 2026-07-23 at 16 06 20" src="https://github.com/user-attachments/assets/16c68049-7eaa-47dc-9cad-2c7dddb0c6f1" />





## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
