### PR TITLE
add AVAudioPlayer API

### DIFF
--- a/Sources/AVAudioPlayer+Android.swift
+++ b/Sources/AVAudioPlayer+Android.swift
@@ -1,5 +1,4 @@
 #if os(Android)
-import Foundation
 import JNI
 
 public protocol AVAudioPlayerDelegate: AnyObject {
@@ -16,13 +15,12 @@ public final class AVAudioPlayer: JNIObject {
     }
 
     @MainActor
-    public convenience init(contentsOf url: URL) throws {
-        let assetName = url.isFileURL ? url.path : url.absoluteString
-        try self.init(arguments: JavaSDLView(getSDLView()), assetName)
+    public convenience init(assetPath: String) throws {
+        try self.init(arguments: JavaSDLView(getSDLView()), assetPath)
         try? call("setSwiftInstancePtr", arguments: [swiftInstancePtr])
     }
 
-    public var deviceCurrentTime: TimeInterval {
+    public var deviceCurrentTime: Double {
         return (try? call("getDeviceCurrentTime")) ?? 0
     }
 
@@ -32,7 +30,7 @@ public final class AVAudioPlayer: JNIObject {
     }
 
     @discardableResult
-    public func play(atTime time: TimeInterval) -> Bool {
+    public func play(atTime time: Double) -> Bool {
         try? call("playAtTime", arguments: [time])
         return true
     }

--- a/Sources/AVAudioPlayer+Android.swift
+++ b/Sources/AVAudioPlayer+Android.swift
@@ -15,8 +15,8 @@ public final class AVAudioPlayer: JNIObject {
     }
 
     @MainActor
-    public convenience init(assetPath: String) throws {
-        try self.init(arguments: JavaSDLView(getSDLView()), assetPath)
+    public convenience init(contentsOf url: URL) throws {
+        try self.init(arguments: JavaSDLView(getSDLView()), url)
         try? call("setSwiftInstancePtr", arguments: [swiftInstancePtr])
     }
 

--- a/Sources/AVAudioPlayer+Android.swift
+++ b/Sources/AVAudioPlayer+Android.swift
@@ -1,0 +1,62 @@
+#if os(Android)
+import Foundation
+import JNI
+
+public protocol AVAudioPlayerDelegate: AnyObject {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool)
+}
+
+public final class AVAudioPlayer: JNIObject {
+    public override static var className: String { "org.uikit.AVAudioPlayer" }
+
+    public weak var delegate: AVAudioPlayerDelegate?
+
+    public var volume: Float = 1.0 {
+        didSet { try? call("setVolume", arguments: [Double(volume)]) }
+    }
+
+    @MainActor
+    public convenience init(contentsOf url: URL) throws {
+        let assetName = url.isFileURL ? url.path : url.absoluteString
+        try self.init(arguments: JavaSDLView(getSDLView()), assetName)
+        try? call("setSwiftInstancePtr", arguments: [swiftInstancePtr])
+    }
+
+    public var deviceCurrentTime: TimeInterval {
+        return (try? call("getDeviceCurrentTime")) ?? 0
+    }
+
+    @discardableResult
+    public func prepareToPlay() -> Bool {
+        return (try? call("prepareToPlay")) ?? false
+    }
+
+    @discardableResult
+    public func play(atTime time: TimeInterval) -> Bool {
+        try? call("playAtTime", arguments: [time])
+        return true
+    }
+
+    deinit {
+        try? call("cleanup")
+    }
+}
+
+@_cdecl("Java_org_uikit_AVAudioPlayer_nativeOnCompletion")
+public func nativeOnAudioPlayerCompletion(
+    env: UnsafeMutablePointer<JNIEnv>,
+    cls: JavaObject,
+    swiftInstancePtr: JavaLong,
+    success: JavaBoolean
+) {
+    guard let player = AVAudioPlayer.from(swiftInstancePtr: swiftInstancePtr) else { return }
+    player.delegate?.audioPlayerDidFinishPlaying(player, successfully: success != 0)
+}
+
+extension AVAudioPlayer {
+    static func from(swiftInstancePtr: JavaLong) -> AVAudioPlayer? {
+        guard let reference = UnsafeRawPointer(bitPattern: Int(swiftInstancePtr)) else { return nil }
+        return Unmanaged<AVAudioPlayer>.fromOpaque(reference).takeUnretainedValue()
+    }
+}
+#endif

--- a/Sources/AVAudioPlayer+Mac.swift
+++ b/Sources/AVAudioPlayer+Mac.swift
@@ -1,0 +1,4 @@
+#if os(macOS)
+@_exported import class AVFoundation.AVAudioPlayer
+@_exported import protocol AVFoundation.AVAudioPlayerDelegate
+#endif

--- a/Sources/AVAudioPlayer+Mac.swift
+++ b/Sources/AVAudioPlayer+Mac.swift
@@ -1,4 +1,8 @@
 #if os(macOS)
+//
+//  AVAudioPlayer+Mac.swift
+//  UIKit
+//
+
 @_exported import class AVFoundation.AVAudioPlayer
-@_exported import protocol AVFoundation.AVAudioPlayerDelegate
 #endif

--- a/Sources/AVPlayer+Android.swift
+++ b/Sources/AVPlayer+Android.swift
@@ -102,11 +102,4 @@ extension AVPlayer {
         return Unmanaged<AVPlayer>.fromOpaque(reference).takeUnretainedValue()
     }
 }
-
-extension JNIObject {
-    var swiftInstancePtr: JavaLong {
-        let ptr = Unmanaged.passUnretained(self).toOpaque()
-        return JavaLong(Int(bitPattern: ptr))
-    }
-}
 #endif

--- a/Sources/AVPlayer+Android.swift
+++ b/Sources/AVPlayer+Android.swift
@@ -20,7 +20,7 @@ public class AVPlayer: JNIObject {
     public convenience init(playerItem: AVPlayerItem) {
         let parentView = JavaSDLView(getSDLView())
         try! self.init(arguments: parentView, playerItem.asset)
-        try! self.call("setSwiftAVPlayerInstancePtr", arguments: [self.swiftAVPlayerInstancePtr])
+        try! self.call("setSwiftAVPlayerInstancePtr", arguments: [self.swiftInstancePtr])
     }
 
     public func play() {
@@ -104,7 +104,7 @@ extension AVPlayer {
 }
 
 extension JNIObject {
-    var swiftAVPlayerInstancePtr: JavaLong {
+    var swiftInstancePtr: JavaLong {
         let ptr = Unmanaged.passUnretained(self).toOpaque()
         return JavaLong(Int(bitPattern: ptr))
     }

--- a/Sources/AVURLAsset+Android.swift
+++ b/Sources/AVURLAsset+Android.swift
@@ -20,10 +20,10 @@ public class AVURLAsset: JNIObject {
     public override static var className: String { "org.uikit.AVURLAsset" }
 
     @MainActor
-    public var url: String?
+    public var url: URL?
 
     @MainActor
-    convenience public init(url: String) {
+    convenience public init(url: URL) {
         try! self.init(arguments: JavaSDLView(getSDLView()), url)
         self.url = url
     }

--- a/Sources/Bundle.swift
+++ b/Sources/Bundle.swift
@@ -10,7 +10,6 @@
 import class Foundation.Bundle
 public typealias Bundle = Foundation.Bundle
 #elseif os(Android)
-import Foundation
 import JNI
 
 private func listFiles(inDirectory subpath: String) throws -> [String] {
@@ -39,10 +38,6 @@ public struct Bundle {
         } else {
             return filename + "." + ext
         }
-    }
-
-    public func url(forResource filename: String, withExtension ext: String?) -> URL? {
-        return path(forResource: filename, ofType: ext ?? "").flatMap(URL.init(string:))
     }
 }
 #endif

--- a/Sources/Bundle.swift
+++ b/Sources/Bundle.swift
@@ -10,6 +10,7 @@
 import class Foundation.Bundle
 public typealias Bundle = Foundation.Bundle
 #elseif os(Android)
+import Foundation
 import JNI
 
 private func listFiles(inDirectory subpath: String) throws -> [String] {
@@ -38,6 +39,10 @@ public struct Bundle {
         } else {
             return filename + "." + ext
         }
+    }
+
+    public func url(forResource filename: String, withExtension ext: String?) -> URL? {
+        return path(forResource: filename, ofType: ext ?? "").flatMap(URL.init(string:))
     }
 }
 #endif

--- a/Sources/JNIObject+swiftInstancePtr.swift
+++ b/Sources/JNIObject+swiftInstancePtr.swift
@@ -1,0 +1,12 @@
+#if os(Android)
+import JNI
+
+extension JNIObject {
+    /// An opaque pointer to `self`, passed to the Java side so native callbacks can
+    /// resolve back to this instance. Shared by AVPlayer and AVAudioPlayer.
+    var swiftInstancePtr: JavaLong {
+        let ptr = Unmanaged.passUnretained(self).toOpaque()
+        return JavaLong(Int(bitPattern: ptr))
+    }
+}
+#endif

--- a/Sources/URL+Android.swift
+++ b/Sources/URL+Android.swift
@@ -1,0 +1,7 @@
+#if os(Android)
+public typealias URL = String
+
+extension String {
+    public init(fileURLWithPath path: String) { self = path }
+}
+#endif

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -121,9 +121,6 @@
 		5CDB31B51F1CCA4F0081A605 /* CGDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDB31B41F1CCA4F0081A605 /* CGDataProvider.swift */; };
 		5CDB31B71F1CE8050081A605 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDB31B61F1CE8050081A605 /* Bundle.swift */; };
 		5CDC14CC1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDC14CB1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift */; };
-		FF0000010000000000000001 /* ShaderProgram+roundedRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */; };
-		FF0000010000000000000003 /* ShaderProgram+shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000004 /* ShaderProgram+shadow.swift */; };
-		FF0000010000000000000005 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000006 /* UIBezierPath.swift */; };
 		5CE5C56F1EDC39E100680154 /* UIPanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C56E1EDC39E100680154 /* UIPanGestureRecognizer.swift */; };
 		5CE5C5711EDC6AA100680154 /* UITapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C5701EDC6AA100680154 /* UITapGestureRecognizer.swift */; };
 		5CE5C5731EDD7C3400680154 /* UIWindow+TouchHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE5C5721EDD7C3400680154 /* UIWindow+TouchHandling.swift */; };
@@ -201,6 +198,10 @@
 		83F02DE11F18F18500347AA8 /* roboto-thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 83F02DC51F17D84000347AA8 /* roboto-thin.ttf */; };
 		83F02DE21F18F18500347AA8 /* roboto-thinitalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 83F02DC61F17D84000347AA8 /* roboto-thinitalic.ttf */; };
 		83F8D4A21F028E6B008D3262 /* CALayer+SDL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83F8D4A11F028E6B008D3262 /* CALayer+SDL.swift */; };
+		B43AFED8FE9C31E0D5161073 /* AVAudioPlayer+Mac.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265504EE5B8409B456C63B78 /* AVAudioPlayer+Mac.swift */; };
+		FF0000010000000000000001 /* ShaderProgram+roundedRect.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */; };
+		FF0000010000000000000003 /* ShaderProgram+shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000004 /* ShaderProgram+shadow.swift */; };
+		FF0000010000000000000005 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0000010000000000000006 /* UIBezierPath.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -218,6 +219,7 @@
 		03760AE51F67E73300F36283 /* UIScrollViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIScrollViewTests.swift; sourceTree = "<group>"; };
 		03C487291F750C8D004BAA0C /* UIPanGestureRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIPanGestureRecognizerTests.swift; sourceTree = "<group>"; };
 		03CC73971FB5B2C6000A2C91 /* UITouchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITouchTests.swift; sourceTree = "<group>"; };
+		265504EE5B8409B456C63B78 /* AVAudioPlayer+Mac.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AVAudioPlayer+Mac.swift"; path = "Sources/AVAudioPlayer+Mac.swift"; sourceTree = SOURCE_ROOT; };
 		5B115C5C1F61DBF800AAB895 /* UIProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UIProgressView.swift; path = Sources/UIProgressView.swift; sourceTree = SOURCE_ROOT; };
 		5B1F87041F4C889F0051A1A2 /* CAMediaTimingFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CAMediaTimingFunction.swift; path = Sources/CAMediaTimingFunction.swift; sourceTree = SOURCE_ROOT; };
 		5B4A782F285C799C0066E48C /* UIWindow+getSafeAreaInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+getSafeAreaInsets.swift"; sourceTree = "<group>"; };
@@ -330,9 +332,6 @@
 		5CDB31B41F1CCA4F0081A605 /* CGDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGDataProvider.swift; sourceTree = "<group>"; };
 		5CDB31B61F1CE8050081A605 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		5CDC14CB1FA0ED2E007CDCA3 /* ShaderProgram+mask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+mask.swift"; sourceTree = "<group>"; };
-		FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+roundedRect.swift"; sourceTree = "<group>"; };
-		FF0000010000000000000004 /* ShaderProgram+shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+shadow.swift"; sourceTree = "<group>"; };
-		FF0000010000000000000006 /* UIBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBezierPath.swift"; sourceTree = "<group>"; };
 		5CE5C56E1EDC39E100680154 /* UIPanGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIPanGestureRecognizer.swift; path = Sources/UIPanGestureRecognizer.swift; sourceTree = SOURCE_ROOT; };
 		5CE5C5701EDC6AA100680154 /* UITapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITapGestureRecognizer.swift; path = Sources/UITapGestureRecognizer.swift; sourceTree = SOURCE_ROOT; };
 		5CE5C5721EDD7C3400680154 /* UIWindow+TouchHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+TouchHandling.swift"; sourceTree = "<group>"; };
@@ -391,6 +390,10 @@
 		83F02DC91F17D84000347AA8 /* roboto-italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "roboto-italic.ttf"; sourceTree = "<group>"; };
 		83F02DCA1F17D84000347AA8 /* roboto-mediumitalic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "roboto-mediumitalic.ttf"; sourceTree = "<group>"; };
 		83F8D4A11F028E6B008D3262 /* CALayer+SDL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+SDL.swift"; sourceTree = "<group>"; };
+		D5910A84544C186631DF699F /* AVAudioPlayer+Android.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "AVAudioPlayer+Android.swift"; path = "Sources/AVAudioPlayer+Android.swift"; sourceTree = SOURCE_ROOT; };
+		FF0000010000000000000002 /* ShaderProgram+roundedRect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+roundedRect.swift"; sourceTree = "<group>"; };
+		FF0000010000000000000004 /* ShaderProgram+shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ShaderProgram+shadow.swift"; sourceTree = "<group>"; };
+		FF0000010000000000000006 /* UIBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBezierPath.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -691,6 +694,8 @@
 				833075391F69768E002089AC /* AVPlayer+Android.swift */,
 				5C4AD7E6204EE45F0021DD4A /* AVPlayerLayer+Android.swift */,
 				83023EC71F9E31D400389F89 /* VideoTexture+Mac.swift */,
+				265504EE5B8409B456C63B78 /* AVAudioPlayer+Mac.swift */,
+				D5910A84544C186631DF699F /* AVAudioPlayer+Android.swift */,
 			);
 			name = Video;
 			sourceTree = "<group>";
@@ -1027,6 +1032,7 @@
 				0371D2291F793E5F005DDFED /* UIScrollView+velocity.swift in Sources */,
 				83AB7B5A1F2B679600C7997D /* UIPinchGestureRecognizer.swift in Sources */,
 				5C93AEA62088FB51005BE853 /* UINavigationBarAndroid.swift in Sources */,
+				B43AFED8FE9C31E0D5161073 /* AVAudioPlayer+Mac.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/main/java/org/uikit/AVAudioPlayer.kt
+++ b/src/main/java/org/uikit/AVAudioPlayer.kt
@@ -1,0 +1,74 @@
+package org.uikit
+
+import android.media.MediaPlayer
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import org.libsdl.app.SDLActivity
+
+@Suppress("unused")
+class AVAudioPlayer(sdlView: SDLActivity, private val assetName: String) {
+    private val context = sdlView.context
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var player: MediaPlayer? = null
+    private var swiftInstancePtr: Long? = null
+    private var volume: Float = 1.0f
+    private var pendingStart: Runnable? = null
+
+    external fun nativeOnCompletion(swiftInstancePtr: Long, success: Boolean)
+
+    fun setSwiftInstancePtr(ptr: Long) {
+        swiftInstancePtr = ptr
+    }
+
+    fun setVolume(newVolume: Double) {
+        volume = newVolume.toFloat()
+        player?.setVolume(volume, volume)
+    }
+
+    fun getDeviceCurrentTime(): Double = SystemClock.uptimeMillis() / 1000.0
+
+    fun prepareToPlay(): Boolean {
+        mainHandler.post {
+            if (player != null) return@post
+            try {
+                val mp = MediaPlayer()
+                context.assets.openFd(assetName).use { afd ->
+                    mp.setDataSource(afd.fileDescriptor, afd.startOffset, afd.length)
+                }
+                mp.setVolume(volume, volume)
+                mp.setOnCompletionListener { onFinished(true) }
+                mp.setOnErrorListener { _, _, _ -> onFinished(false); true }
+                mp.prepare()
+                player = mp
+            } catch (e: Exception) {
+                Log.e("AVAudioPlayer", "Failed to prepare $assetName", e)
+                onFinished(false)
+            }
+        }
+        return true
+    }
+
+    fun playAtTime(timeInSeconds: Double) {
+        val runnable = Runnable { player?.start() }
+        pendingStart = runnable
+        val targetUptimeMs = (timeInSeconds * 1000).toLong().coerceAtLeast(SystemClock.uptimeMillis())
+        mainHandler.postAtTime(runnable, targetUptimeMs)
+    }
+
+    fun cleanup() {
+        mainHandler.post {
+            pendingStart?.let { mainHandler.removeCallbacks(it) }
+            player?.release()
+            player = null
+        }
+    }
+
+    private fun onFinished(success: Boolean) {
+        player?.release()
+        player = null
+        swiftInstancePtr?.let { nativeOnCompletion(it, success) }
+    }
+}


### PR DESCRIPTION
## What

Add `AVAudioPlayer` API so consumers can play bundled audio

- **Android:** new JNI-backed `AVAudioPlayer` shim (`Sources/AVAudioPlayer+Android.swift`) plus its Kotlin counterpart (`org.uikit.AVAudioPlayer`, backed by `MediaPlayer`). Foundation-free — takes a `String` asset path (not `URL`), uses `Double` instead of `TimeInterval`, and no `NSObject` — so it doesn't drag `libFoundation.so` into the link closure.
- **macOS:** `Sources/AVAudioPlayer+Mac.swift` re-exports `AVFoundation.AVAudioPlayer` via `@_exported import class`, mirroring how `AVPlayerItem+Mac.swift` exposes the video types, so `import UIKit` gives you the audio player too.
- **Shared helper:** the `JNIObject.swiftInstancePtr` helper (opaque pointer to `self` for native callbacks) is generalized from the old AVPlayer-specific name and moved to its own file (`JNIObject+swiftInstancePtr.swift`), now shared by both `AVPlayer` and `AVAudioPlayer`.

## Testing

Builds green on both macOS and Android; verified the Android build has no `libFoundation.so` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)