### PR TITLE
premultipliedRGBA and CGRect Union

### DIFF
--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -92,6 +92,18 @@ public class CGImage {
         GPU_UpdateImageBytes(rawPointer, &rect, bytes, Int32(rawPointer.pointee.w) * Int32(bytesPerPixel))
     }
 
+    /// Builds an image from premultiplied-RGBA bytes (R,G,B,A in memory, alpha-premultiplied), composited with
+    /// premultiplied blending. Mirrors the iOS CoreGraphics factory of the same name so callers have one path.
+    public static func premultipliedRGBA(_ bytes: UnsafePointer<UInt8>, width: Int, height: Int) -> CGImage? {
+        guard width > 0, height > 0,
+              let pointer = GPU_CreateImage(UInt16(width), UInt16(height), GPU_FORMAT_RGBA) else { return nil }
+        var rect = GPU_Rect(x: 0, y: 0, w: Float(width), h: Float(height))
+        GPU_UpdateImageBytes(pointer, &rect, bytes, Int32(width) * 4)
+        guard let image = CGImage(pointer, sourceData: nil) else { return nil }
+        GPU_SetBlendMode(image.rawPointer, GPU_BLEND_PREMULTIPLIED_ALPHA)
+        return image
+    }
+
     /// Recreate the underlying `GPU_Image` (`self.rawPointer`) from this `CGImage`'s source data if possible.
     /// - Returns: `true`, if it was possible to recreate the image. Or `false`, if there was no underlying source data, or when SDL_gpu could not decode that data.
     internal func reloadFromSourceData() -> Bool {

--- a/Sources/CGPoint.swift
+++ b/Sources/CGPoint.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 flowkey. All rights reserved.
 //
 
-public struct CGPoint {
+public struct CGPoint: Sendable {
     public var x: CGFloat = 0
     public var y: CGFloat = 0
     

--- a/Sources/CGRect.swift
+++ b/Sources/CGRect.swift
@@ -7,7 +7,7 @@
 //
 
 
-public struct CGRect {
+public struct CGRect: Sendable {
     public var origin: CGPoint
     public var size: CGSize
 
@@ -108,6 +108,16 @@ extension CGRect {
         } else {
             return .null
         }
+    }
+
+    public func union(_ other: CGRect) -> CGRect {
+        if isNull { return other }
+        if other.isNull { return self }
+        let minX = Swift.min(self.minX, other.minX)
+        let minY = Swift.min(self.minY, other.minY)
+        let maxX = Swift.max(self.maxX, other.maxX)
+        let maxY = Swift.max(self.maxY, other.maxY)
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 }
 


### PR DESCRIPTION
**Type of change:** feature (API parity with Apple's UIKit / CoreGraphics)

## Motivation (current vs expected behavior)

Adds a few small APIs the cross-platform UIKit was missing relative to Apple's

- **`CGImage.premultipliedRGBA(_:width:height:)`** — builds a `CGImage` from premultiplied-ARGB pixel bytes, composited with premultiplied blending (`GPU_BLEND_PREMULTIPLIED_ALPHA`). Mirrors the CoreGraphics factory of the same name on iOS, so callers can feed one buffer format on every platform instead of diverging RGBA/ARGB paths.
- **`CGRect.union(_:)`** — the standard CoreGraphics API (with the usual null-rect handling), previously absent.
- **`CGPoint` / `CGRect: Sendable`** — Apple's CoreGraphics geometry types are already `Sendable` (and `CGSize` here already was); this brings the other two in line. Required to pass rects across Swift Concurrency actor boundaries.

All additive — no behaviour change to existing call sites.
