### PR TITLE
Fix Android SIGSEGV: don't free CGImage textures against a destroyed GL context

### DIFF
--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -119,8 +119,8 @@ public class CGImage {
 
         // Free the old GPU_Image before replacing it (this may be our last chance),
         // but only if it still belongs to the live context. If its context was already
-        // destroyed (stale generation) the texture is gone with it, and freeing it here
-        // would crash against a dangling context (see `deinit`).
+        // destroyed (stale generation), freeing it here would make GL calls against a
+        // dangling context and crash (see `deinit`).
         if contextGeneration == UIScreen.contextGeneration {
             GPU_FreeImage(rawPointer)
         }
@@ -146,8 +146,13 @@ public class CGImage {
             // Android background→foreground cycle a *new* context exists (so
             // `UIScreen.main != nil` passes) but this image belongs to the old,
             // destroyed one; freeing it makes GL calls against a dangling context
-            // and crashes (SIGSEGV in `GPU_FreeImage`). A stale image's texture was
-            // already freed with its context, so skipping the free leaks nothing.
+            // and crashes (SIGSEGV in `GPU_FreeImage`).
+            //
+            // Skipping the free doesn't leak texture memory — that went away with the
+            // context. It does leak the small CPU-side `GPU_Image`/`GPU_IMAGE_DATA`
+            // structs that `GPU_FreeImage` would also have `SDL_free`d (a few dozen
+            // bytes per image that was still alive at teardown), which is a much
+            // better trade than crashing.
             guard UIScreen.main != nil, generation == UIScreen.contextGeneration else { return }
             GPU_FreeImage(pointer)
         }

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -12,6 +12,11 @@ public class CGImage {
     /// This allows us to recreate the image if our OpenGL Context gets killed (esp. relevant for Android)
     private let sourceData: Data?
 
+    /// The `UIScreen.contextGeneration` under which `rawPointer`'s `GPU_Image` was created.
+    /// Used by `deinit` / `reloadFromSourceData()` to avoid freeing a texture whose GL
+    /// context has since been destroyed (which would crash with `SIGSEGV`).
+    private var contextGeneration: UInt64
+
     public let width: Int
     public let height: Int
 
@@ -29,6 +34,7 @@ public class CGImage {
         }
 
         self.sourceData = sourceData
+        self.contextGeneration = UIScreen.contextGeneration
         rawPointer = pointer
 
         GPU_SetSnapMode(rawPointer, GPU_SNAP_POSITION_AND_DIMENSIONS)
@@ -111,14 +117,20 @@ public class CGImage {
             return false
         }
 
-        // Free the old GPU_Image before replacing it (this may be our last chance)
-        GPU_FreeImage(rawPointer)
+        // Free the old GPU_Image before replacing it (this may be our last chance),
+        // but only if it still belongs to the live context. If its context was already
+        // destroyed (stale generation) the texture is gone with it, and freeing it here
+        // would crash against a dangling context (see `deinit`).
+        if contextGeneration == UIScreen.contextGeneration {
+            GPU_FreeImage(rawPointer)
+        }
 
         // If we don't increase the new image's refcount it will be deinited along
         // with the CGImageRef that goes out of scope at the end of this function.
         newImage.rawPointer.pointee.refcount += 1
 
         self.rawPointer = newImage.rawPointer
+        self.contextGeneration = newImage.contextGeneration
 
         return true
     }
@@ -128,8 +140,15 @@ public class CGImage {
         // while a context exists. `CGImage` isn't `@MainActor`, so it can be released off-main or
         // after teardown — hop to the main actor and skip the free if the screen is already gone.
         let pointer = rawPointer
+        let generation = contextGeneration
         Task { @MainActor in
-            guard UIScreen.main != nil else { return }
+            // Only free if this image's GL context is still the live one. After an
+            // Android background→foreground cycle a *new* context exists (so
+            // `UIScreen.main != nil` passes) but this image belongs to the old,
+            // destroyed one; freeing it makes GL calls against a dangling context
+            // and crashes (SIGSEGV in `GPU_FreeImage`). A stale image's texture was
+            // already freed with its context, so skipping the free leaks nothing.
+            guard UIScreen.main != nil, generation == UIScreen.contextGeneration else { return }
             GPU_FreeImage(pointer)
         }
     }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -27,9 +27,10 @@ public extension UIScreen {
     @MainActor
     internal(set) static var lastKnownScreenScale: CGFloat?
 
-    /// Incremented every time a new GL context (a new `UIScreen`) is created.
-    /// A `CGImage` records the generation it was created under so that, at
-    /// free-time, we can tell whether its owning context is still the live one.
+    /// Incremented every time a GL context (a `UIScreen`) is created *or* destroyed.
+    /// A `CGImage` records the generation it was created under, so that at free-time
+    /// `generation == contextGeneration` means exactly "the context that owns this
+    /// image is still the live one".
     /// Without this, an image created before an Android background→foreground
     /// cycle would be freed against the *new* context and crash (`SIGSEGV` in
     /// `GPU_FreeImage`). See `CGImage.deinit` / `CGImage.reloadFromSourceData()`.
@@ -153,6 +154,11 @@ public final class UIScreen {
     }
 
     deinit {
+        // This context is going away: bump the generation so every `CGImage` created
+        // under it is immediately identifiable as stale, without relying on
+        // `UIScreen.main` being nil for the whole teardown→reinit window.
+        UIScreen.contextGeneration &+= 1
+
         MainActor.assumeIsolated {
             UIView.completePendingAnimations()
             UIView.layersWithAnimations.removeAll()

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -26,6 +26,19 @@ public extension UIScreen {
     /// briefly nil (teardown/reinit). `nil` only before any screen has ever existed.
     @MainActor
     internal(set) static var lastKnownScreenScale: CGFloat?
+
+    /// Incremented every time a new GL context (a new `UIScreen`) is created.
+    /// A `CGImage` records the generation it was created under so that, at
+    /// free-time, we can tell whether its owning context is still the live one.
+    /// Without this, an image created before an Android background→foreground
+    /// cycle would be freed against the *new* context and crash (`SIGSEGV` in
+    /// `GPU_FreeImage`). See `CGImage.deinit` / `CGImage.reloadFromSourceData()`.
+    ///
+    /// `nonisolated(unsafe)` so `CGImage` (which isn't `@MainActor`) can read it
+    /// when creating/freeing images. All real accesses happen on the main/GL
+    /// thread (creating or freeing a GPU_Image requires a current context), so
+    /// this is safe in practice.
+    nonisolated(unsafe) internal static var contextGeneration: UInt64 = 0
 }
 
 @MainActor
@@ -48,6 +61,11 @@ public final class UIScreen {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
+
+        // A new UIScreen owns a freshly-created GL context. Bump the generation
+        // so `CGImage`s created from here on are tagged with this context, and
+        // images from previous (now-destroyed) contexts can be identified as stale.
+        UIScreen.contextGeneration &+= 1
     }
 
     convenience init() {


### PR DESCRIPTION
**Type of change:** bug fix

## Motivation

Fixes the ongoing Android crash:
https://app.bugsnag.com/flowkey/mobile-app/errors/69644a5e4ef4ae6af7fd0f05

`SIGSEGV` in `renderer_GL_common.inl:3923`, inside `GPU_FreeImage`. Android only.
Last 30 days: 108 events, 106 users; 198 events / 192 users all time. First seen
2026-01-12, still happening on 2.113.2. It correlates with the app going to the
background and coming back.

### Root cause

On Android, backgrounding tears down the `UIScreen` and its GL context
(`UIScreen.main = nil` → `UIScreen.deinit` → `GPU_Quit()`); resuming builds a
**new** `UIScreen`/context. A `CGImage` created under the **old** context can
then be freed *after* the new context exists, and `CGImage.deinit`'s guard only
checked `UIScreen.main != nil` — which passes, because a (new) screen exists. So
`GPU_FreeImage` ran against an image whose `context_target` is freed memory →
crash. The guard asked "does *a* screen exist?", not "is the context that owns
*this* image still alive?".

Why it reliably lands after the resume: `deinit` frees via `Task { @MainActor }`,
and Android pauses our render loop while backgrounded, so jobs queued during
teardown only drain on the first frame after resume — the stack trace shows the
free inside `nativeProcessEventsAndRender`.

Why sdl-gpu's own guard doesn't help: it compares
`image->renderer == GPU_GetCurrentRenderer()`, but the renderer is `SDL_malloc`'d
and `SDL_free`'d (`renderer_GLES_2.c:32`/`:62`), so the `GPU_Init` after
`GPU_Quit` usually gets the same address back and the comparison passes
spuriously.

### Fix

Tag each `CGImage` with the `UIScreen.contextGeneration` it was created under,
and only call `GPU_FreeImage` when that generation is still the current one —
in both `deinit` and `reloadFromSourceData()`. The counter is bumped whenever a
GL context is created *or destroyed*, so "generation matches" means exactly
"the context that owns this image is still live", without depending on
`UIScreen.main` being nil for the whole teardown→reinit window.

Skipping the free doesn't leak texture memory (that goes with the context), but
it does leak the small `GPU_Image`/`GPU_IMAGE_DATA` structs — `FreeImage`'s two
`SDL_free` calls sit outside the GL branch. ~100 bytes per live image per
background cycle. Freeing them properly needs a registry of live `CGImage`s
torn down before `GPU_Quit()`; follow-up, not a blocker.

## Notes / testing
- Couldn't reproduce locally (POCO M3 / Adreno). Adreno keeps the GL context on
  background, so it rarely triggers; the crash mostly hits Samsung/Mali devices.
- Not verified locally — please review carefully, and confirm via the Bugsnag
  count dropping after release.
- Follow-up: bump submodules UIKit-SDL → NativePlayer → mobile-app once merged.

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs
