### PR TITLE
Fix mask clip rect not scaling

### DIFF
--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -58,7 +58,8 @@ extension CALayer {
 
         // If a mask exists, take it into account when rendering by combining absoluteFrame with the mask's frame
         if let mask = mask {
-   
+            // The mask's frame is in this layer's own (bounds) coordinate space, so it must go through the
+            // same transform as the layer's content to become an absolute clip rect.
             let maskFrame = (mask._presentation ?? mask).frame
             let maskAbsoluteFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin).applying(modelViewTransform)
 

--- a/Sources/CALayer+SDL.swift
+++ b/Sources/CALayer+SDL.swift
@@ -58,9 +58,9 @@ extension CALayer {
 
         // If a mask exists, take it into account when rendering by combining absoluteFrame with the mask's frame
         if let mask = mask {
-            // XXX: we're probably not doing exactly what iOS does if there is a transform on here somewhere
+   
             let maskFrame = (mask._presentation ?? mask).frame
-            let maskAbsoluteFrame = maskFrame.offsetBy(absoluteFrame.origin)
+            let maskAbsoluteFrame = maskFrame.offsetBy(deltaFromAnchorPointToOrigin).applying(modelViewTransform)
 
             // Don't intersect with previousClippingRect: in a case where both `masksToBounds` and `mask` are
             // present, using previousClippingRect would not constrain the area as much as it might otherwise


### PR DESCRIPTION
Fixes # <!--- Add issue here. Remove if N/A -->


Before
<img width="1388" height="869" alt="Screenshot 2026-08-04 at 18 31 02" src="https://github.com/user-attachments/assets/92650dee-2352-45d2-a9c6-0b8fef346f17" />
After
<img width="1207" height="759" alt="Screenshot 2026-08-04 at 18 27 52" src="https://github.com/user-attachments/assets/4568b6e3-0404-4342-b839-7db80c091637" />


## Motivation (current vs expected behavior)

Sticky panel was clipped on Android tablets because the horizontal sheet scales up but he mask clip rect wasn't scaled to match. Now runs the mask frame through the same modelViewTransform as the layer's content.


## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
