### PR TITLE
implement CALayer+ContentsFilter

### DIFF
--- a/Sources/CALayer+ContentsFilter.swift
+++ b/Sources/CALayer+ContentsFilter.swift
@@ -1,11 +1,3 @@
-/*
- * Apples CALayerContentsFilter is a struct with static members, for backwards compatibility.
- * We implemented it with an enum, which can be used the same way as Apples CALayerContentsFilter.
- *
- * Apple's `.nearest` and `magnificationFilter` are missing: SDL_gpu sets the minification and magnification
- * filters from a single value, so neither would behave the way it does on iOS. Failing to compile is better
- * than differing quietly.
- */
 public enum CALayerContentsFilter {
     case linear
     case trilinear

--- a/Sources/CALayer+ContentsFilter.swift
+++ b/Sources/CALayer+ContentsFilter.swift
@@ -1,0 +1,12 @@
+/*
+ * Apples CALayerContentsFilter is a struct with static members, for backwards compatibility.
+ * We implemented it with an enum, which can be used the same way as Apples CALayerContentsFilter.
+ *
+ * Apple's `.nearest` and `magnificationFilter` are missing: SDL_gpu sets the minification and magnification
+ * filters from a single value, so neither would behave the way it does on iOS. Failing to compile is better
+ * than differing quietly.
+ */
+public enum CALayerContentsFilter {
+    case linear
+    case trilinear
+}

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -212,7 +212,7 @@ open class CALayer {
         shadowOpacity = layer.shadowOpacity
         mask = layer.mask
         masksToBounds = layer.masksToBounds
-        minificationFilter = layer.minificationFilter // must precede `contents`, whose didSet applies it
+        minificationFilter = layer.minificationFilter
         contents = layer.contents // XXX: we should make a copy here
         contentsScale = layer.contentsScale
         superlayer = layer.superlayer

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -12,10 +12,7 @@ open class CALayer {
     }
 
     open var minificationFilter: CALayerContentsFilter = .linear {
-        didSet {
-            guard minificationFilter != oldValue else { return }
-            contents?.setMinificationFilter(minificationFilter)
-        }
+        didSet { contents?.setMinificationFilter(minificationFilter) }
     }
 
     /// Defaults to 1.0 but if the layer is associated with a view,

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -5,7 +5,20 @@ open class CALayer {
     open weak var delegate: CALayerDelegate?
 
     open var contents: CGImage? {
-        didSet { CALayer.layerTreeIsDirty = true }
+        didSet {
+            CALayer.layerTreeIsDirty = true
+            contents?.setMinificationFilter(minificationFilter)
+        }
+    }
+
+    /// How `contents` is sampled when drawn smaller than it was rendered. `.trilinear` builds a mip chain and
+    /// blends between levels, which is what keeps thin lines from breaking up and crawling under a changing
+    /// scale; it costs roughly 50% more texture memory, so it isn't the default.
+    open var minificationFilter: CALayerContentsFilter = .linear {
+        didSet {
+            guard minificationFilter != oldValue else { return }
+            contents?.setMinificationFilter(minificationFilter)
+        }
     }
 
     /// Defaults to 1.0 but if the layer is associated with a view,
@@ -202,6 +215,8 @@ open class CALayer {
         shadowOpacity = layer.shadowOpacity
         mask = layer.mask
         masksToBounds = layer.masksToBounds
+        // Before `contents`: assigning that applies this filter to the texture, which both layers share.
+        minificationFilter = layer.minificationFilter
         contents = layer.contents // XXX: we should make a copy here
         contentsScale = layer.contentsScale
         superlayer = layer.superlayer

--- a/Sources/CALayer.swift
+++ b/Sources/CALayer.swift
@@ -11,9 +11,6 @@ open class CALayer {
         }
     }
 
-    /// How `contents` is sampled when drawn smaller than it was rendered. `.trilinear` builds a mip chain and
-    /// blends between levels, which is what keeps thin lines from breaking up and crawling under a changing
-    /// scale; it costs roughly 50% more texture memory, so it isn't the default.
     open var minificationFilter: CALayerContentsFilter = .linear {
         didSet {
             guard minificationFilter != oldValue else { return }
@@ -215,8 +212,7 @@ open class CALayer {
         shadowOpacity = layer.shadowOpacity
         mask = layer.mask
         masksToBounds = layer.masksToBounds
-        // Before `contents`: assigning that applies this filter to the texture, which both layers share.
-        minificationFilter = layer.minificationFilter
+        minificationFilter = layer.minificationFilter // must precede `contents`, whose didSet applies it
         contents = layer.contents // XXX: we should make a copy here
         contentsScale = layer.contentsScale
         superlayer = layer.superlayer

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -106,8 +106,6 @@ public class CGImage {
         return image
     }
 
-    /// Persisted so a texture rebuilt after GPU context loss (`reloadFromSourceData`) comes back filtered the
-    /// same way, rather than silently reverting to bilinear.
     private var minificationFilter: CALayerContentsFilter = .linear
 
     internal func setMinificationFilter(_ filter: CALayerContentsFilter) {
@@ -116,14 +114,13 @@ public class CGImage {
         applyMinificationFilter()
     }
 
-    /// Unconditional, unlike `setMinificationFilter`: used to restore the filter onto a fresh texture.
     private func applyMinificationFilter() {
         switch minificationFilter {
         case .linear:
             GPU_SetImageFilter(rawPointer, GPU_FILTER_LINEAR)
         case .trilinear:
             if !rawPointer.pointee.has_mipmaps { GPU_GenerateMipmaps(rawPointer) }
-            // Must follow the generate, which leaves a nearest-level filter behind.
+            // Generating leaves the texture picking a single nearest mip level, so set the blending filter after.
             GPU_SetImageFilter(rawPointer, GPU_FILTER_LINEAR_MIPMAP)
         }
     }

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -104,6 +104,25 @@ public class CGImage {
         return image
     }
 
+    /// Remembered so a texture rebuilt after GPU context loss (`reloadFromSourceData`) comes back filtered the
+    /// same way, rather than silently reverting to bilinear.
+    private var minificationFilter: CALayerContentsFilter = .linear
+
+    /// Filtering lives on the texture, so an image shared by two layers takes the filter of whichever set its
+    /// `contents` last. Mipmaps also can't be un-generated: once `.trilinear` has been set, `.linear` samples
+    /// them with nearest level selection rather than going back to plain bilinear.
+    internal func setMinificationFilter(_ filter: CALayerContentsFilter) {
+        minificationFilter = filter
+        switch filter {
+        case .linear:
+            GPU_SetImageFilter(rawPointer, GPU_FILTER_LINEAR)
+        case .trilinear:
+            if !rawPointer.pointee.has_mipmaps { GPU_GenerateMipmaps(rawPointer) }
+            // Must follow the generate, which leaves a nearest-level filter behind.
+            GPU_SetImageFilter(rawPointer, GPU_FILTER_LINEAR_MIPMAP)
+        }
+    }
+
     /// Recreate the underlying `GPU_Image` (`self.rawPointer`) from this `CGImage`'s source data if possible.
     /// - Returns: `true`, if it was possible to recreate the image. Or `false`, if there was no underlying source data, or when SDL_gpu could not decode that data.
     internal func reloadFromSourceData() -> Bool {
@@ -119,6 +138,7 @@ public class CGImage {
         newImage.rawPointer.pointee.refcount += 1
 
         self.rawPointer = newImage.rawPointer
+        setMinificationFilter(minificationFilter)
 
         return true
     }

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -104,13 +104,10 @@ public class CGImage {
         return image
     }
 
-    /// Remembered so a texture rebuilt after GPU context loss (`reloadFromSourceData`) comes back filtered the
+    /// Persisted so a texture rebuilt after GPU context loss (`reloadFromSourceData`) comes back filtered the
     /// same way, rather than silently reverting to bilinear.
     private var minificationFilter: CALayerContentsFilter = .linear
 
-    /// Filtering lives on the texture, so an image shared by two layers takes the filter of whichever set its
-    /// `contents` last. Mipmaps also can't be un-generated: once `.trilinear` has been set, `.linear` samples
-    /// them with nearest level selection rather than going back to plain bilinear.
     internal func setMinificationFilter(_ filter: CALayerContentsFilter) {
         minificationFilter = filter
         switch filter {

--- a/Sources/CGImage.swift
+++ b/Sources/CGImage.swift
@@ -90,6 +90,8 @@ public class CGImage {
     public func replacePixels(with bytes: UnsafePointer<UInt8>, bytesPerPixel: Int) {
         var rect = GPU_Rect(x: 0, y: 0, w: Float(rawPointer.pointee.w), h: Float(rawPointer.pointee.h))
         GPU_UpdateImageBytes(rawPointer, &rect, bytes, Int32(rawPointer.pointee.w) * Int32(bytesPerPixel))
+        // Otherwise the mip chain keeps serving the pixels we just replaced.
+        if rawPointer.pointee.has_mipmaps { GPU_GenerateMipmaps(rawPointer) }
     }
 
     /// Builds an image from premultiplied-RGBA bytes (R,G,B,A in memory, alpha-premultiplied), composited with
@@ -109,8 +111,14 @@ public class CGImage {
     private var minificationFilter: CALayerContentsFilter = .linear
 
     internal func setMinificationFilter(_ filter: CALayerContentsFilter) {
+        guard filter != minificationFilter else { return }
         minificationFilter = filter
-        switch filter {
+        applyMinificationFilter()
+    }
+
+    /// Unconditional, unlike `setMinificationFilter`: used to restore the filter onto a fresh texture.
+    private func applyMinificationFilter() {
+        switch minificationFilter {
         case .linear:
             GPU_SetImageFilter(rawPointer, GPU_FILTER_LINEAR)
         case .trilinear:
@@ -135,7 +143,7 @@ public class CGImage {
         newImage.rawPointer.pointee.refcount += 1
 
         self.rawPointer = newImage.rawPointer
-        setMinificationFilter(minificationFilter)
+        applyMinificationFilter()
 
         return true
     }

--- a/Sources/CGRect.swift
+++ b/Sources/CGRect.swift
@@ -28,6 +28,8 @@ public struct CGRect: Sendable {
 
     public var isNull: Bool { return self == .null }
 
+    public var isEmpty: Bool { return size.width <= 0 || size.height <= 0 }
+
     public static let null = CGRect(x: .infinity, y: .infinity, width: 0, height: 0)
     public static let zero = CGRect()
 }

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -44,10 +44,26 @@ public final class UIScreen {
     }
     nonisolated public let scale: CGFloat
 
+    /// The GPU's `GL_MAX_TEXTURE_SIZE`. Callers rastering their own images have to respect it themselves:
+    /// sdl-gpu never validates a size, so `GPU_CreateImage` hands back a non-nil but incomplete texture
+    /// above the limit, which renders as garbage with no error anywhere.
+    nonisolated public let maxTextureSize: CGFloat
+
     private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect, scale: CGFloat) {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
+        self.maxTextureSize = Self.getMaxTextureSize()
+    }
+
+    private static func getMaxTextureSize() -> CGFloat {
+        let GL_MAX_TEXTURE_SIZE: UInt32 = 0x0D33
+        typealias GetIntegerv = @convention(c) (UInt32, UnsafeMutablePointer<Int32>) -> Void
+        var value: Int32 = 0
+        unsafeBitCast(
+            SDL_GL_GetProcAddress("glGetIntegerv")!, to: GetIntegerv.self
+        )(GL_MAX_TEXTURE_SIZE, &value)
+        return CGFloat(value)
     }
 
     convenience init() {

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -44,27 +44,16 @@ public final class UIScreen {
     }
     nonisolated public let scale: CGFloat
 
-    /// The GPU's `GL_MAX_TEXTURE_SIZE`. Callers rastering their own images have to respect it themselves:
-    /// sdl-gpu never validates a size, so `GPU_CreateImage` hands back a non-nil but incomplete texture
-    /// above the limit, which renders as garbage with no error anywhere.
+    /// The GPU's `GL_MAX_TEXTURE_SIZE`, or 0 without a GPU context. Callers rastering their own images have
+    /// to respect it themselves: sdl-gpu never validates a size, so `GPU_CreateImage` hands back a non-nil
+    /// but incomplete texture above the limit, which renders as garbage with no error anywhere.
     nonisolated public let maxTextureSize: CGFloat
 
     private init(renderTarget: UnsafeMutablePointer<GPU_Target>!, bounds: CGRect, scale: CGFloat) {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
-        // No render target (the test `dummyScreen`) means no GL context to query; 0 signals "no GPU".
-        self.maxTextureSize = renderTarget != nil ? Self.getMaxTextureSize() : 0
-    }
-
-    private static func getMaxTextureSize() -> CGFloat {
-        let GL_MAX_TEXTURE_SIZE: UInt32 = 0x0D33
-        typealias GetIntegerv = @convention(c) (UInt32, UnsafeMutablePointer<Int32>) -> Void
-        var value: Int32 = 0
-        unsafeBitCast(
-            SDL_GL_GetProcAddress("glGetIntegerv")!, to: GetIntegerv.self
-        )(GL_MAX_TEXTURE_SIZE, &value)
-        return CGFloat(value)
+        self.maxTextureSize = CGFloat(GPU_GetMaxTextureSize())
     }
 
     convenience init() {

--- a/Sources/UIScreen.swift
+++ b/Sources/UIScreen.swift
@@ -53,7 +53,8 @@ public final class UIScreen {
         self.rawPointer = renderTarget
         self.bounds = bounds
         self.scale = scale
-        self.maxTextureSize = Self.getMaxTextureSize()
+        // No render target (the test `dummyScreen`) means no GL context to query; 0 signals "no GPU".
+        self.maxTextureSize = renderTarget != nil ? Self.getMaxTextureSize() : 0
     }
 
     private static func getMaxTextureSize() -> CGFloat {

--- a/UIKit.xcodeproj/project.pbxproj
+++ b/UIKit.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		5C27E7E51ECB2F9100F5020D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C27E7DB1ECB2F9100F5020D /* Foundation.framework */; };
 		5C27E80F1ECB301900F5020D /* SDL2-Shims.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C27E7FC1ECB301900F5020D /* SDL2-Shims.swift */; };
 		5C32F2C420A1C69C006D64C5 /* UIScreen+Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C32F2C320A1C69C006D64C5 /* UIScreen+Errors.swift */; };
+		FEDCBA040000000000000011 /* CALayer+ContentsFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDCBA040000000000000001 /* CALayer+ContentsFilter.swift */; };
 		5C361E231ECC348700B3F561 /* UIView+SDL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C361E221ECC348700B3F561 /* UIView+SDL.swift */; };
 		5C3716B61F10050600B2C366 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3716B51F10050600B2C366 /* Timer.swift */; };
 		5C3DCCEF2090F072001DEDAF /* UIAlertControllerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C3DCCEE2090F072001DEDAF /* UIAlertControllerView.swift */; };
@@ -261,6 +262,7 @@
 		5C27E7DB1ECB2F9100F5020D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		5C27E7FC1ECB301900F5020D /* SDL2-Shims.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SDL2-Shims.swift"; sourceTree = "<group>"; };
 		5C32F2C320A1C69C006D64C5 /* UIScreen+Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScreen+Errors.swift"; sourceTree = "<group>"; };
+		FEDCBA040000000000000001 /* CALayer+ContentsFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+ContentsFilter.swift"; sourceTree = "<group>"; };
 		5C361E221ECC348700B3F561 /* UIView+SDL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+SDL.swift"; sourceTree = "<group>"; };
 		5C3716B51F10050600B2C366 /* Timer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
 		5C3DCCEE2090F072001DEDAF /* UIAlertControllerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAlertControllerView.swift; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				5C27E7FC1ECB301900F5020D /* SDL2-Shims.swift */,
 				5C3716B51F10050600B2C366 /* Timer.swift */,
 				5C32F2C320A1C69C006D64C5 /* UIScreen+Errors.swift */,
+				FEDCBA040000000000000001 /* CALayer+ContentsFilter.swift */,
 				5C361E221ECC348700B3F561 /* UIView+SDL.swift */,
 			);
 			name = SDL;
@@ -1029,6 +1032,7 @@
 				61C9D3BB21B052B30012018B /* NotificationCenter.swift in Sources */,
 				5CE5C5781EDDAD8200680154 /* CGRect.swift in Sources */,
 				5C32F2C420A1C69C006D64C5 /* UIScreen+Errors.swift in Sources */,
+				FEDCBA040000000000000011 /* CALayer+ContentsFilter.swift in Sources */,
 				0371D2291F793E5F005DDFED /* UIScrollView+velocity.swift in Sources */,
 				83AB7B5A1F2B679600C7997D /* UIPinchGestureRecognizer.swift in Sources */,
 				5C93AEA62088FB51005BE853 /* UINavigationBarAndroid.swift in Sources */,


### PR DESCRIPTION
**Type of change:** feature

## Motivation (current vs expected behavior)

Contents drawn smaller than they were rendered are sampled bilinearly, with no way to change it. Minifying by much more than 1:1 undersamples — thin lines break up and crawl as the scale changes.

This adds Apple's `CALayer.minificationFilter`, so a layer can ask for `.trilinear`: mipmaps, blended between levels. Costs ~50% more texture memory (measured on Mali-G710), so `.linear` stays the default.

The caller is the FKDL sheet renderer in NativePlayer, which rasters tiles once for the sharpest zoom the sheet can reach and then only ever scales them down — minification is its normal state, not an edge case.

## Notes

- Filtering lives on the texture, not the layer, so an image shared by two layers takes the filter of whichever set `contents` last.
- Mipmaps can't be un-generated: after `.trilinear`, `.linear` samples them with nearest level selection rather than reverting to plain bilinear.
- `.nearest` and `magnificationFilter` are deliberately absent — SDL_gpu sets the minification and magnification filters from a single value, so neither would behave as it does on iOS. Failing to compile beats differing quietly.
- `replacePixels` does not regenerate mipmaps. Nothing pairs it with `.trilinear` today; two lines when something does.

## Please check if the PR fulfills these requirements
- [ ] Self-review: I am confident this is the simplest and clearest way to achieve the expected behaviour
- [ ] There are no dependencies on other PRs or I have linked dependencies through Zenhub
- [ ] The commit messages are clean and understandable
- [ ] Tests for the changes have been added (for bug fixes / features)
